### PR TITLE
react-script should be a devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,10 +44,10 @@
     "react-dom": "^16.13.1",
     "react-html-parser": "^2.0.2",
     "react-router-dom": "5.2.0",
-    "react-scripts": "^4.0.0",
     "uuid": "^8.3.1"
   },
   "devDependencies": {
+    "react-scripts": "^4.0.0",
     "eslint": "^6.6.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-standard": "^14.1.1",


### PR DESCRIPTION
See https://github.com/facebook/create-react-app/issues/2696

There are probably few others, we should move as much as possible into devDependency, to keep the runtime leaner.