### PR TITLE
Update README.md - Git Proxy Kick Off Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The idea is quite simple, scan outgoing attempts to push to public repository an
 
 Of course every corporation will have different procedures so a key feature has to be the extensibility of the framework.
 
-To watch a demo of Git Proxy, checkout the [recording of the Kickoff call](https://drive.google.com/drive/folders/1kyoOcCCK1CHdsCNr6qRnQBdsxp-dF8wO?usp=sharing) of January 28th 2021.
+To watch a demo of Git Proxy, checkout the [recording of the Kickoff call](https://www.finos.org/hubfs/FINOS/2021%20Audio%20and%20Video/FINOS%20Git%20Proxy%20Kickoff%20-%2027%20Jan%2021.mp4) of January 28th 2021.
 
 ## Project Installation Instructions
 


### PR DESCRIPTION
Linked to HS hosted video. (old link was to FINOS internal Google Drive - could not access unless in finos.org login)

Use this link: https://www.finos.org/hubfs/FINOS/2021%20Audio%20and%20Video/FINOS%20Git%20Proxy%20Kickoff%20-%2027%20Jan%2021.mp4

But let me know if it breaks.