### PR TITLE
Set NPM publish to public access for initial release

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -13,6 +13,6 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npm publish
+      - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
When publishing a scoped package for the first time, the following must be set:

```bash
npm publish --access=public
```
The following run failed due to the lack of the `--access` flag:

https://github.com/finos/git-proxy/actions/runs/5394794276