### PR TITLE
fix: commit lint bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "@finos/git-proxy",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@material-ui/core": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "server-test-ci": "mocha --exit",
     "server-test": "mocha --exit",
     "test": "mocha --exit",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "preinstall": "npx husky install"
   },
   "author": "Paul Groves",
   "license": "Apache-2.0",


### PR DESCRIPTION
Introduced a preinstall hook that ensures that [husky](https://typicode.github.io/husky/) is installed after a npm install.
Checks for proper commit messages should pass properly after this.