### PR TITLE
fix: add prepare hook for husky install

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "server-test": "mocha --exit",
     "test": "mocha --exit",
     "eject": "react-scripts eject",
-    "preinstall": "npx husky install",
     "prepare": "node ./scripts/prepare.js"
   },
   "author": "Paul Groves",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "server-test": "mocha --exit",
     "test": "mocha --exit",
     "eject": "react-scripts eject",
-    "preinstall": "npx husky install"
+    "preinstall": "npx husky install",
+    "prepare": "node ./scripts/prepare.js"
   },
   "author": "Paul Groves",
   "license": "Apache-2.0",

--- a/scripts/prepare.js
+++ b/scripts/prepare.js
@@ -1,0 +1,41 @@
+// =======
+// Import.
+// =======
+
+const { execSync } = require('child_process');
+const { existsSync } = require('fs');
+
+// ===========
+// File paths.
+// ===========
+
+const FILE_COMMIT = './.husky/commit-msg';
+const FILE_HUSKY = './.husky/_/husky.sh';
+
+// =========
+// Commands.
+// =========
+
+const COMMIT_MSG_STRING = `'npx --no -- commitlint --edit $'{1}''`
+const CLI_COMMIT = `npx husky add .husky/commit-msg ${COMMIT_MSG_STRING}`;
+const CLI_HUSKY = 'npx husky install';
+
+// ==============
+// Husky install.
+// ==============
+
+// this will create .husky/_/husky.sh if it does not yet exist.
+if (!existsSync(FILE_HUSKY)) {
+	global.console.log(CLI_HUSKY);
+	execSync(CLI_HUSKY);
+}
+
+// ====================
+// Add pre-commit hook.
+// ====================
+
+// this will create .husky/commit-msg if it does not yet exist.
+if (!existsSync(FILE_COMMIT)) {
+	global.console.log(CLI_COMMIT);
+	execSync(CLI_COMMIT);
+}


### PR DESCRIPTION
Fix #188

Verified by running ```npm run prepare``` that files in .husky are created from the script as they currently are.

Should we remove the preinstall script too @JamieSlome