### PR TITLE
fix: add pre-commit lint hook to husky

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx --no -- commitlint --edit ${1}
+npx --no -- commitlint --edit ${1} && npm run lint


### PR DESCRIPTION
Closes #241 

@JamieSlome Tested and verified on local by creating linting issues and then trying to commit. This fixes any auto fixable issues and doesn't allow the commit to go through if it can't fix them all. User can see the errors in the ```Command Output``` as well in the ```Problems``` console where it would be highlighted already.

As for the separate ```.prettierrc``` file that we had discussed, we don't really need this one here as we are already using ```eslint-plugin-prettier``` and ```eslint-config-prettier``` which essentially combine eslint with prettier to work together and work to avoid any conflicts. In case any conflicts still come up or specific customisation is needed, they are defined in the rules object in the ```eslintrc.cjs``` file. For more details, you can refer [here](https://prettier.io/docs/en/integrating-with-linters). 