### PR TITLE
fix: run lint check only on pull requests

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: Lint Code Base
 
-on: [push, pull_request]
+on: [pull_request]
 
 env: # environment variables (available in any part of the action)
   NODE_VERSION: 16


### PR DESCRIPTION
Runs lint workflow only on pull requests instead of the previous behaviour where it was running on push as well as pull requests.

Discussed in #258