### PR TITLE
fix: cleanup deprecated behaviour from react-router

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -20,7 +20,7 @@ const hist = createBrowserHistory();
 ReactDOM.render(
   <Router history={hist}>
     <Routes>
-      <Route exact path="/admin" element={<Admin />} />
+      <Route exact path="/admin/*" element={<Admin />} />
       <Route exact path="/login" element={<Login />} />
       <Route exact path="/" element={<Navigate from="/" to="/login" />} />
     </Routes>

--- a/src/ui/layouts/Admin.jsx
+++ b/src/ui/layouts/Admin.jsx
@@ -15,20 +15,19 @@ let ps;
 
 const switchRoutes = (
   <Routes>
-    {routes.map((prop, key) => {
-      if (prop.layout === '/admin') {
+    {routes
+      .filter((prop, _) => prop.layout === '/admin')
+      .map((prop, key) => {
         return (
           <Route
             exact
-            path={prop.layout + prop.path}
-            element={prop.component}
+            path={prop.path}
             key={key}
+            element={<prop.component />}
           />
         );
-      }
-      return null;
-    })}
-    <Navigate from="/admin" to="/admin/dashboard" />
+      })}
+    <Route exact path="/admin" element={<Navigate to="/admin/dashboard" />} />
   </Routes>
 );
 

--- a/src/ui/views/Login/Login.jsx
+++ b/src/ui/views/Login/Login.jsx
@@ -79,7 +79,7 @@ export default function UserProfile() {
   }
 
   if (success) {
-    return <Navigate to={{ pathname: '/', state: { authed: true } }} />;
+    return <Navigate to={{ pathname: '/admin', state: { authed: true } }} />;
   }
 
   return (

--- a/src/ui/views/PushDetails/PushDetails.jsx
+++ b/src/ui/views/PushDetails/PushDetails.jsx
@@ -3,7 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { Navigate } from 'react-router-dom';
 import moment from 'moment';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import Icon from '@material-ui/core/Icon';
 import GridItem from '../../components/Grid/GridItem.jsx';
 import GridContainer from '../../components/Grid/GridContainer.jsx';
@@ -26,9 +26,9 @@ import {
   cancelPush,
 } from '../../services/git-push.js';
 
-export default function Dashboard(props) {
+export default function Dashboard() {
   // eslint-disable-next-line react/prop-types
-  const id = props.match.params.id;
+  const { id } = useParams();
   const [data, setData] = useState([]);
   const [auth, setAuth] = useState(true);
   const [isLoading, setIsLoading] = useState(true);

--- a/src/ui/views/User/User.jsx
+++ b/src/ui/views/User/User.jsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import React, { useState, useEffect } from 'react';
-import { Navigate } from 'react-router-dom';
+import { Navigate, useParams } from 'react-router-dom';
 import Icon from '@material-ui/core/Icon';
 import GridItem from '../../components/Grid/GridItem.jsx';
 import GridContainer from '../../components/Grid/GridContainer.jsx';
@@ -28,23 +28,23 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export default function Dashboard(props) {
+export default function Dashboard() {
   const classes = useStyles();
   const [data, setData] = useState([]);
   const [auth, setAuth] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
+  const { id } = useParams();
 
   useEffect(() => {
     // eslint-disable-next-line react/prop-types
-    const id = props.match.params.id;
     if (id) {
       getUser(setIsLoading, setData, setAuth, setIsError, id);
     } else {
       console.log('getting user data');
       getUser(setIsLoading, setData, setAuth, setIsError);
     }
-  }, [props]);
+  }, [id]);
 
   if (isLoading) return <div>Loading ...</div>;
   if (isError) return <div>Something went wrong ...</div>;


### PR DESCRIPTION
preface: not well versed in front-end or React. Tidying up a series of errors seen when pulling up the ui. A follow-up from #185 

- fix redirect from `/login` to `/admin` on submit. It would dump you back to the main login page and wouldnt redirect.
- fix below error when loading `/admin` by replacing `<Navigate />` with a `<Route ...element={<Navigate />} />` component:
    ```
    Uncaught Error: [Navigate] is not a <Route> component. All component children of <Routes> must be a <Route> or <React.Fragment>
    ```

- make parent route /admin/* so children are routed correctly:
    ```
    You rendered descendant <Routes> (or called `useRoutes()`) at "/admin" (under <Route path="/admin">) but the parent route path has no trailing "*". This means if you navigate deeper, the parent won't match anymore and therefore the child routes will never render.
    ```
- convert raw props to useParams() in components with URL path params
    ```
    props.match is undefined
    ```
- in /admin/* Route setup, pass components as elements via JSX to resolve error:
    ```
    Functions are not valid as a React child. This may happen if you return a Component instead of <Component /> from render.
    ```