### PR TITLE
feat: allow ports to be customised via env vars

### DIFF
--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,6 +1,3 @@
-const {
-  GIT_PROXY_SERVER_PORT = 8000,
-  GIT_PROXY_UI_PORT = 8080
-} = process.env;
+const { GIT_PROXY_SERVER_PORT = 8000, GIT_PROXY_UI_PORT = 8080 } = process.env;
 
-exports.Vars = { GIT_PROXY_SERVER_PORT, GIT_PROXY_UI_PORT};
+exports.Vars = { GIT_PROXY_SERVER_PORT, GIT_PROXY_UI_PORT };

--- a/src/config/env.js
+++ b/src/config/env.js
@@ -1,0 +1,6 @@
+const {
+  GIT_PROXY_SERVER_PORT = 8000,
+  GIT_PROXY_UI_PORT = 8080
+} = process.env;
+
+exports.Vars = { GIT_PROXY_SERVER_PORT, GIT_PROXY_UI_PORT};

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser');
 const routes = require('./routes');
 const config = require('../config');
 const db = require('../db');
-const proxyHttpPort = process.env.GIT_PROXY_SERVER_PORT || 8000;
+const { GIT_PROXY_SERVER_PORT: proxyHttpPort } = require('../config/env').Vars;
 
 const options = {
   inflate: true,
@@ -33,7 +33,7 @@ const start = async () => {
   });
 
   proxyApp.listen(proxyHttpPort, () => {
-    console.log(`Listening on ${proxyHttpPort}`);
+    console.log(`!Listening on ${proxyHttpPort}`);
   });
 
   return proxyApp;

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -4,7 +4,7 @@ const bodyParser = require('body-parser');
 const routes = require('./routes');
 const config = require('../config');
 const db = require('../db');
-const proxyHttpPort = 8000;
+const proxyHttpPort = process.env.GIT_PROXY_SERVER_PORT || 8000;
 
 const options = {
   inflate: true,

--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -33,7 +33,7 @@ const start = async () => {
   });
 
   proxyApp.listen(proxyHttpPort, () => {
-    console.log(`!Listening on ${proxyHttpPort}`);
+    console.log(`Listening on ${proxyHttpPort}`);
   });
 
   return proxyApp;

--- a/src/proxy/processors/push-action/blockForAuth.js
+++ b/src/proxy/processors/push-action/blockForAuth.js
@@ -1,6 +1,6 @@
 const Step = require('../../actions').Step;
 
-const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const { GIT_PROXY_UI_PORT: uiPort } = require('../../../config/env').Vars;
 
 const exec = async (req, action) => {
   const step = new Step('authBlock');

--- a/src/proxy/processors/push-action/blockForAuth.js
+++ b/src/proxy/processors/push-action/blockForAuth.js
@@ -1,12 +1,14 @@
 const Step = require('../../actions').Step;
 
+const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+
 const exec = async (req, action) => {
   const step = new Step('authBlock');
 
   const message =
     '\n\n\n' +
     `Git Proxy has received your push:\n\n` +
-    `http://localhost:8080/requests/${action.id}` +
+    `http://localhost:${uiPort}/requests/${action.id}` +
     '\n\n\n';
   step.setAsyncBlock(message);
   action.addStep(step);

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -3,7 +3,7 @@ const session = require('express-session');
 const http = require('http');
 const cors = require('cors');
 const app = express();
-const port = 8080;
+const port = process.env.GIT_PROXY_UI_PORT || 8080;
 
 const _httpServer = http.createServer(app);
 

--- a/src/service/index.js
+++ b/src/service/index.js
@@ -3,7 +3,8 @@ const session = require('express-session');
 const http = require('http');
 const cors = require('cors');
 const app = express();
-const port = process.env.GIT_PROXY_UI_PORT || 8080;
+
+const { GIT_PROXY_UI_PORT: uiPort } = require('../config/env').Vars;
 
 const _httpServer = http.createServer(app);
 
@@ -33,9 +34,9 @@ const start = async () => {
   app.use(express.urlencoded({ extended: true }));
   app.use('/', routes);
 
-  await _httpServer.listen(port);
+  await _httpServer.listen(uiPort);
 
-  console.log(`Service Listening on ${port}`);
+  console.log(`Service Listening on ${uiPort}`);
   app.emit('ready');
 
   return app;

--- a/src/ui/services/git-push.js
+++ b/src/ui/services/git-push.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const { GIT_PROXY_UI_PORT: uiPort } = require('../../config/env').Vars;
 const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {

--- a/src/ui/services/git-push.js
+++ b/src/ui/services/git-push.js
@@ -1,14 +1,15 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const baseUrl = 'http://localhost:8080/api/v1';
+const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {
   withCredentials: true,
 };
 
 const getUser = async (setIsLoading, setData, setAuth, setIsError) => {
-  const url = new URL(`http://localhost:8080/auth/success`);
+  const url = new URL(`http://localhost:${uiPort}/auth/success`);
   await axios(url.toString(), config)
     .then((response) => {
       const data = response.data;

--- a/src/ui/services/repo.js
+++ b/src/ui/services/repo.js
@@ -1,7 +1,8 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const baseUrl = 'http://localhost:8080/api/v1';
+const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {
   withCredentials: true,

--- a/src/ui/services/repo.js
+++ b/src/ui/services/repo.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const { GIT_PROXY_UI_PORT: uiPort } = require('../../config/env').Vars;
 const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {

--- a/src/ui/services/user.js
+++ b/src/ui/services/user.js
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const { GIT_PROXY_UI_PORT: uiPort } = require('../../config/env').Vars;
 const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {

--- a/src/ui/services/user.js
+++ b/src/ui/services/user.js
@@ -1,7 +1,8 @@
 /* eslint-disable max-len */
 /* eslint-disable require-jsdoc */
 import axios from 'axios';
-const baseUrl = 'http://localhost:8080';
+const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const baseUrl = `http://localhost:${uiPort}/api/v1`;
 
 const config = {
   withCredentials: true,

--- a/src/ui/views/Login/Login.jsx
+++ b/src/ui/views/Login/Login.jsx
@@ -37,6 +37,9 @@ const styles = {
   },
 };
 
+const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const baseUrl = `http://localhost:${uiPort}`;
+
 const useStyles = makeStyles(styles);
 
 export default function UserProfile() {
@@ -54,7 +57,7 @@ export default function UserProfile() {
   function handleSubmit(event) {
     axios
       .post(
-        'http://localhost:8080/auth/login',
+        `${baseUrl}/auth/login`,
         {
           username: username,
           password: password,

--- a/src/ui/views/Login/Login.jsx
+++ b/src/ui/views/Login/Login.jsx
@@ -37,7 +37,7 @@ const styles = {
   },
 };
 
-const uiPort = process.env.GIT_PROXY_UI_PORT || 8080;
+const { GIT_PROXY_UI_PORT: uiPort } = require('../../config/env').Vars;
 const baseUrl = `http://localhost:${uiPort}`;
 
 const useStyles = makeStyles(styles);

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -10,7 +10,6 @@ const expect = chai.expect;
 describe('default configuration', function () {
   it('should use default values if no user-settings.json file exists', function () {
     const config = require('../src/config');
-    const env = require('../src/config/env');
 
     expect(config.getAuthentication()).to.be.eql(
       defaultSettings.authentication[0],
@@ -22,40 +21,6 @@ describe('default configuration', function () {
     expect(config.getAuthorisedList()).to.be.eql(
       defaultSettings.authorisedList,
     );
-
-    expect(env.Vars.GIT_PROXY_SERVER_PORT).to.be.eql(
-      8000
-    );
-    expect(env.Vars.GIT_PROXY_UI_PORT).to.be.eql(
-      8080
-    );
-
-  });
-  after(function () {
-    delete require.cache[require.resolve('../src/config')];
-  });
-});
-
-describe('custom ports', function () {
-  const originalEnv = process.env;
-  before(function () {
-    process.env = {
-      ...originalEnv,
-      GIT_PROXY_SERVER_PORT: 9000,
-      GIT_PROXY_UI_PORT: 9090
-    };
-  });
-
-  it('should use custom ports defined by environment variables', function () {
-    const env = require('../src/config/env');
-
-    expect(env.Vars.GIT_PROXY_SERVER_PORT).to.be.eql(
-      9000
-    );
-    expect(env.Vars.GIT_PROXY_UI_PORT).to.be.eql(
-      9090
-    );
-
   });
   after(function () {
     delete require.cache[require.resolve('../src/config')];

--- a/test/testConfig.js
+++ b/test/testConfig.js
@@ -10,6 +10,7 @@ const expect = chai.expect;
 describe('default configuration', function () {
   it('should use default values if no user-settings.json file exists', function () {
     const config = require('../src/config');
+    const env = require('../src/config/env');
 
     expect(config.getAuthentication()).to.be.eql(
       defaultSettings.authentication[0],
@@ -21,6 +22,40 @@ describe('default configuration', function () {
     expect(config.getAuthorisedList()).to.be.eql(
       defaultSettings.authorisedList,
     );
+
+    expect(env.Vars.GIT_PROXY_SERVER_PORT).to.be.eql(
+      8000
+    );
+    expect(env.Vars.GIT_PROXY_UI_PORT).to.be.eql(
+      8080
+    );
+
+  });
+  after(function () {
+    delete require.cache[require.resolve('../src/config')];
+  });
+});
+
+describe('custom ports', function () {
+  const originalEnv = process.env;
+  before(function () {
+    process.env = {
+      ...originalEnv,
+      GIT_PROXY_SERVER_PORT: 9000,
+      GIT_PROXY_UI_PORT: 9090
+    };
+  });
+
+  it('should use custom ports defined by environment variables', function () {
+    const env = require('../src/config/env');
+
+    expect(env.Vars.GIT_PROXY_SERVER_PORT).to.be.eql(
+      9000
+    );
+    expect(env.Vars.GIT_PROXY_UI_PORT).to.be.eql(
+      9090
+    );
+
   });
   after(function () {
     delete require.cache[require.resolve('../src/config')];

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -43,6 +43,14 @@ Or with npx:
 npx -- @finos/git-proxy --config ./config.json
 ```
 
+### Change ports
+By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the UI frontend; 
+you can change ports by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
+environment variables.
+
+Note that `GIT_PROXY_UI_PORT` is needed for both server and UI Node processes, 
+whereas `GIT_PROXY_SERVER_PORT` is only needed by the server process.
+
 ### Validate configuration
 
 To validate your Git Proxy configuration, run:

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -45,7 +45,7 @@ npx -- @finos/git-proxy --config ./config.json
 
 ### Change ports
 By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the frontend application.
-you can change ports by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
+The ports can be changed by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
 environment variables:
 
 ```

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -43,7 +43,7 @@ Or with npx:
 npx -- @finos/git-proxy --config ./config.json
 ```
 
-### Change ports
+### Set ports with ENV variables
 By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the frontend application.
 The ports can be changed by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
 environment variables:

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -44,7 +44,7 @@ npx -- @finos/git-proxy --config ./config.json
 ```
 
 ### Change ports
-By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the UI frontend; 
+By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the frontend application.
 you can change ports by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
 environment variables:
 

--- a/website/docs/configuration/overview.mdx
+++ b/website/docs/configuration/overview.mdx
@@ -46,7 +46,12 @@ npx -- @finos/git-proxy --config ./config.json
 ### Change ports
 By default, Git Proxy uses port 8000 to expose the Git Server and 8080 for the UI frontend; 
 you can change ports by setting the `GIT_PROXY_SERVER_PORT` and `GIT_PROXY_UI_PORT` 
-environment variables.
+environment variables:
+
+```
+export GIT_PROXY_UI_PORT="5000"
+export GIT_PROXY_SERVER_PORT="9090"
+```
 
 Note that `GIT_PROXY_UI_PORT` is needed for both server and UI Node processes, 
 whereas `GIT_PROXY_SERVER_PORT` is only needed by the server process.


### PR DESCRIPTION
Closes #378 

To test this PR:

```
npm install -g
export GIT_PROXY_UI_PORT="5000"
export GIT_PROXY_SERVER_PORT="9090"
git-proxy
```

You should see:
```
Service Listening on 5000
Listening on 9090
```