### PR TITLE
fix(ci): set CODECOV_TOKEN after action upgrade

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -61,7 +61,7 @@ jobs:
       uses: codecov/codecov-action@v4.0.1
       with:
         files: ./coverage/lcov.info
-        flags: unittests
+        token: ${{ secrets.CODECOV_TOKEN }}
     # - name: Exit if coverage condition not met
     #   if: ${{ steps.test.outputs.exit_code }} != 0
     #   run: exit ${{ steps.test.outputs.exit_code }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -45,19 +45,7 @@ jobs:
       run: |
         npm run test-coverage-ci || echo "Silently ignoring coverage threshold limit..."
 
-    - name: Check if a valid lcov.info file is generated
-      id: check-lcov-non-empty
-      run: |
-        if [ -s "./coverage/lcov.info" ]; then
-          echo "lcov.info is not empty."
-          echo "isNotEmpty=true" >> $GITHUB_OUTPUT
-        else
-          echo "lcov.info is empty."
-          echo "isNotEmpty=false" >> $GITHUB_OUTPUT
-        fi
-
     - name: Upload test coverage report
-      if: ${{ steps.check-lcov-non-empty.outputs.isNotEmpty == 'true'}}
       uses: codecov/codecov-action@v4.0.1
       with:
         files: ./coverage/lcov.info
@@ -65,4 +53,3 @@ jobs:
     # - name: Exit if coverage condition not met
     #   if: ${{ steps.test.outputs.exit_code }} != 0
     #   run: exit ${{ steps.test.outputs.exit_code }}
-

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 [![FINOS - Incubating](https://cdn.jsdelivr.net/gh/finos/contrib-toolbox@master/images/badge-incubating.svg)](https://community.finos.org/docs/governance/Software-Projects/stages/incubating)
 [![NPM](https://img.shields.io/npm/v/@finos/git-proxy?colorA=00C586&colorB=000000)](https://www.npmjs.com/package/@finos/git-proxy)
 [![Build](https://img.shields.io/github/actions/workflow/status/finos/git-proxy/nodejs.yml?branch=main&label=CI&logo=github&colorA=00C586&colorB=000000)](https://github.com/finos/git-proxy/actions/workflows/nodejs.yml)
+[![codecov](https://codecov.io/gh/finos/git-proxy/branch/main/graph/badge.svg)](https://codecov.io/gh/finos/git-proxy)
 [![Documentation](https://img.shields.io/badge/_-documentation-000000?colorA=00C586&logo=docusaurus&logoColor=FFFFFF&)](https://git-proxy.finos.org)
 <br />
 [![License](https://img.shields.io/github/license/finos/git-proxy?colorA=00C586&colorB=000000)](https://github.com/finos/git-proxy/blob/main/LICENSE)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,9 +1,9 @@
 /* eslint-disable max-len */
 'use strict';
 
-const { execFileSync } = require('child_process');
+// const { execFileSync } = require('child_process');
 
-let opts = {
+const opts = {
   branches: 80,
   lines: 80,
   functions: 80,
@@ -13,29 +13,29 @@ let opts = {
 // Only generate coverage report for changed files in PR
 // see: https://github.com/actions/checkout/issues/438#issuecomment-1446882066
 //      https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-if (process.env.GITHUB_BASE_REF !== undefined) {
-  console.log('Generating coverage report for changed files...');
-  try {
-    const baseRef = execFileSync('git', [
-      'rev-parse',
-      `origin/${process.env.GITHUB_BASE_REF}`,
-    ])
-      .toString()
-      .replace('\n', '');
-    const headRef = process.env.GITHUB_SHA;
-    const stdout = execFileSync('git', [
-      'diff',
-      '--name-only',
-      `${baseRef}..${headRef}`,
-    ]).toString();
-    opts = {
-      ...opts,
-      include: stdout.split('\n'),
-    };
-  } catch (error) {
-    console.log('Error: ', error);
-  }
-}
+// if (process.env.GITHUB_BASE_REF !== undefined) {
+//   console.log('Generating coverage report for changed files...');
+//   try {
+//     const baseRef = execFileSync('git', [
+//       'rev-parse',
+//       `origin/${process.env.GITHUB_BASE_REF}`,
+//     ])
+//       .toString()
+//       .replace('\n', '');
+//     const headRef = process.env.GITHUB_SHA;
+//     const stdout = execFileSync('git', [
+//       'diff',
+//       '--name-only',
+//       `${baseRef}..${headRef}`,
+//     ]).toString();
+//     opts = {
+//       ...opts,
+//       include: stdout.split('\n'),
+//     };
+//   } catch (error) {
+//     console.log('Error: ', error);
+//   }
+// }
 
 console.log('nyc config: ', opts);
 module.exports = opts;

--- a/nyc.config.js
+++ b/nyc.config.js
@@ -1,41 +1,9 @@
-/* eslint-disable max-len */
-'use strict';
-
-// const { execFileSync } = require('child_process');
-
 const opts = {
   branches: 80,
   lines: 80,
   functions: 80,
   statements: 80,
 };
-
-// Only generate coverage report for changed files in PR
-// see: https://github.com/actions/checkout/issues/438#issuecomment-1446882066
-//      https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-// if (process.env.GITHUB_BASE_REF !== undefined) {
-//   console.log('Generating coverage report for changed files...');
-//   try {
-//     const baseRef = execFileSync('git', [
-//       'rev-parse',
-//       `origin/${process.env.GITHUB_BASE_REF}`,
-//     ])
-//       .toString()
-//       .replace('\n', '');
-//     const headRef = process.env.GITHUB_SHA;
-//     const stdout = execFileSync('git', [
-//       'diff',
-//       '--name-only',
-//       `${baseRef}..${headRef}`,
-//     ]).toString();
-//     opts = {
-//       ...opts,
-//       include: stdout.split('\n'),
-//     };
-//   } catch (error) {
-//     console.log('Error: ', error);
-//   }
-// }
 
 console.log('nyc config: ', opts);
 module.exports = opts;


### PR DESCRIPTION
Fixes #441 

- codecov-action@v4 requires the token to be set
- flags are not necessary at this time. its [used to differentiate](https://docs.codecov.com/docs/flags) test types and/or sub-components in a monorepo. For now, we just want to see all test coverage across the whole project.