### PR TITLE
feat: print error message for unknown argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ const argv = require('yargs/yargs')(process.argv.slice(2))
       required: false,
       alias: 'c',
     },
-  }).argv;
+  })
+  .strict().argv;
 
 require('./src/config/file').configFile = argv.c ? argv.c : undefined;
 


### PR DESCRIPTION
Fixes #473 .

Any command-line argument given that is not demanded, or does not have a corresponding description, will be reported as an error. This helps to avoid issues with command line arguments having typos, e.g. --configg 

Correct command line arguments: no change in behaviour
```
git-proxy --config my-config.json 
Listening on 8000
Service Listening on 8080
```

Typo in command line argument: error message printed
``` 
git-proxy --configg my-config.json
Usage: git-proxy [options]

Options:
      --help      Show help                                            [boolean]
      --version   Show version number                                  [boolean]
  -v, --validate  Check the proxy.config.json file in the current working
                  directory for validation errors.
  -c, --config    Path to custom git-proxy configuration file.
                                                  [default: "proxy.config.json"]

Unknown argument: configg
```

Unknown command line arguments: error message printed
```
git-proxy -- --config my-config.json --unknown --strange
Usage: git-proxy [options]

Options:
      --help      Show help                                            [boolean]
      --version   Show version number                                  [boolean]
  -v, --validate  Check the proxy.config.json file in the current working
                  directory for validation errors.
  -c, --config    Path to custom git-proxy configuration file.
                                                  [default: "proxy.config.json"]

Unknown arguments: unknown, strange
```