### PR TITLE
fix: health check endpoint api name

### DIFF
--- a/src/service/routes/home.js
+++ b/src/service/routes/home.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = new express.Router();
 
 const resource = {
-  healthcheck: '/api/v1/healhcheck',
+  healthcheck: '/api/v1/healthcheck',
   push: '/api/v1/push',
   auth: '/api/v1/auth',
 };


### PR DESCRIPTION
Fixes #475 .

Typo fixed in health check API endpoint definition, to be /api/v1/healthcheck .

```
{"healthcheck":"/api/v1/healthcheck","push":"/api/v1/push","auth":"/api/v1/auth"}
```