### PR TITLE
Report on coverage only and block CI on tests failure #495

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Test
       id: test
       run: |
-        npm run test-coverage-ci || echo "Silently ignoring coverage threshold limit..."
+        npm run test-coverage-ci
 
     - name: Upload test coverage report
       uses: codecov/codecov-action@v4.1.0

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "server-test": "mocha --exit",
     "test": "mocha --exit",
     "test-coverage": "nyc npm run test",
-    "test-coverage-ci": "nyc --reporter=lcovonly --reporter=text --check-coverage npm run test",
+    "test-coverage-ci": "nyc --reporter=lcovonly --reporter=text npm run test",
     "prepare": "node ./scripts/prepare.js",
     "lint": "eslint --fix . --ext .js,.jsx",
     "gen-schema-doc": "node ./scripts/doc-schema.js"


### PR DESCRIPTION
Currently failing tests are not reported to the CI pipeline resulting in pull requests being merged even when tests are failing 👍