### PR TITLE
Remove development run time from `fail-on-scope` (Dependency Review) ✅ 

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,4 +17,4 @@ jobs:
         comment-summary-in-pr: always
         fail-on-severity: high
         allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, BSD-2-Clause, Unlicense, CC0-1.0, 0BSD, X11, MPL-2.0, MPL-1.0, MPL-1.1, MPL-2.0
-        fail-on-scopes: development, runtime
+        fail-on-scopes: runtime

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "build": "docusaurus build",
     "publish-gh-pages": "docusaurus deploy"
   },
-  "dependencies": {
+  "devDependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
     "classnames": "^2.2.6",


### PR DESCRIPTION
Unblocks CI for #506 & #335