### PR TITLE
Add `caniuse-lite` to `allow-dependencies-licenses` for Dependency Review

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,3 +18,4 @@ jobs:
         fail-on-severity: high
         allow-licenses: MIT, Apache-2.0, BSD-3-Clause, ISC, BSD-2-Clause, Unlicense, CC0-1.0, 0BSD, X11, MPL-2.0, MPL-1.0, MPL-1.1, MPL-2.0
         fail-on-scopes: development, runtime
+        allow-dependencies-licenses: 'pkg:npm/caniuse-lite'


### PR DESCRIPTION
Closes #520 