### PR TITLE
Remove auth headers from bare git clone on server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Deploy custom push protections and policies on top of Git.",
   "scripts": {
     "cli": "node ./packages/git-proxy-cli/index.js",

--- a/src/proxy/processors/push-action/pullRemote.js
+++ b/src/proxy/processors/push-action/pullRemote.js
@@ -21,26 +21,9 @@ const exec = async (req, action) => {
 
     const cmd = `git clone ${action.url} --bare`;
 
-    // Retrieve authorization headers
-    const authorizationHeader = req.headers?.authorization;
+    step.log(`Exectuting ${cmd}`);
 
-    // Validate the authorization headers
-    const authorizationValid =
-      authorizationHeader &&
-      typeof authorizationHeader === 'string' &&
-      authorizationHeader.includes('Basic ');
-
-    // Construct clone URL depending on presence of authorization headers
-    const cloneUrl = authorizationValid
-      ? `https://${Buffer.from(authorizationHeader.split(' ')[1], 'base64')}@${action.url.replace(
-          /https*:\/\//,
-          '',
-        )}`
-      : action.url;
-
-    step.log(`Exectuting ${cmd}${authorizationValid ? ' with credentials' : ''}`);
-
-    const response = spawnSync('git', ['clone', cloneUrl, '--bare', '--progress'], {
+    const response = spawnSync('git', ['clone', action.url, '--bare', '--progress'], {
       cwd: action.proxyGitPath,
       encoding: 'utf-8',
     });

--- a/website/docs/installation.mdx
+++ b/website/docs/installation.mdx
@@ -22,7 +22,7 @@ npm install -g @finos/git-proxy-cli
 To install a specific version of Git Proxy, append the version to the end of the install command:
 
 ```bash
-npm install -g @finos/git-proxy@1.2.0
+npm install -g @finos/git-proxy@1.2.1
 ```
 
 To install a specific version of the Git Proxy CLI, append the version to the end of the install command:

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -11,7 +11,7 @@ module.exports = {
   projectName: `${projectName}`,
   organizationName: 'FINOS',
   customFields: {
-    version: '1.2.0',
+    version: '1.2.1',
   },
   scripts: ['https://buttons.github.io/buttons.js'],
   stylesheets: ['https://fonts.googleapis.com/css?family=Overpass:400,400i,700'],


### PR DESCRIPTION
Removes the usage of auth headers for shallow clones of upstream repositories for diff generation.