### PR TITLE
chore(ci): update release.yml paths to include package.json and package-lock.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,8 @@ on:
       - 'scripts/**'
       - 'public/**'
       - 'packages/**'
-
+      - 'package.json'
+      - 'package-lock.json'
 
 permissions:
   contents: read


### PR DESCRIPTION
Include `package.json` and `package-lock.json` as included paths for automated releases. This primarily addresses dependency updates introduced by Renovate bot.