### PR TITLE
chore(ci): disable auto release until auto version bumping implemented

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,60 @@
----
-name: Release
+# ---
+# name: Release
 
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    paths:
-      - 'src/**'
-      - 'test/**'
-      - 'scripts/**'
-      - 'public/**'
-      - 'packages/**'
-      - 'package.json'
-      - 'package-lock.json'
+# on:
+#   workflow_dispatch:
+#   push:
+#     branches:
+#       - main
+#     paths:
+#       - 'src/**'
+#       - 'test/**'
+#       - 'scripts/**'
+#       - 'public/**'
+#       - 'packages/**'
+#       - 'package.json'
+#       - 'package-lock.json'
 
-permissions:
-  contents: read
+# permissions:
+#   contents: read
 
-jobs:
-  create_github_release:
-    outputs:
-      full-tag: ${{ steps.release-drafter.outputs.tag_name }}
-      short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
-      body: ${{ steps.release-drafter.outputs.body }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: read
-    steps:
-      - uses: release-drafter/release-drafter@v6
-        id: release-drafter
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          publish: true
-      - name: Get the short tag
-        id: get_tag_name
-        run: |
-          short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
-          echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
-  create_npm_release:
-    needs: create_github_release
-    runs-on: ubuntu-latest
-    permissions:
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-    steps:
-      - uses: actions/checkout@8459bc0 # v4
-      - uses: actions/setup-node@c2ac33f # v4, Setup .npmrc file to publish to npm
-        with:
-          node-version: '18.x'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm ci
-      - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+# jobs:
+#   create_github_release:
+#     outputs:
+#       full-tag: ${{ steps.release-drafter.outputs.tag_name }}
+#       short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
+#       body: ${{ steps.release-drafter.outputs.body }}
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: write
+#       pull-requests: read
+#     steps:
+#       - uses: release-drafter/release-drafter@v6
+#         id: release-drafter
+#         env:
+#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#         with:
+#           publish: true
+#       - name: Get the short tag
+#         id: get_tag_name
+#         run: |
+#           short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
+#           echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
+#   create_npm_release:
+#     needs: create_github_release
+#     runs-on: ubuntu-latest
+#     permissions:
+#       packages: write
+#     env:
+#       REGISTRY: ghcr.io
+#       IMAGE_NAME: ${{ github.repository }}
+#     steps:
+#       - uses: actions/checkout@8459bc0 # v4
+#       - uses: actions/setup-node@c2ac33f # v4, Setup .npmrc file to publish to npm
+#         with:
+#           node-version: '18.x'
+#           registry-url: 'https://registry.npmjs.org'
+#       - run: npm ci
+#       - run: npm publish --access=public
+#         env:
+#           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Disabling auto release until #557 has been implemented. #557 is required to ensure that the contents of a tag and release don't fall out of sync with the version reflected in the `package.json` and `package-lock.json`.

@eddie-knight, I know we can bump the version using `npm version major | minor | patch` however don't know from our workflow how to calculate whether the release is major, minor or patch. Any ideas from your implementation?