### PR TITLE
chore: add npm run build step to CI workflow

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -13,6 +13,7 @@ jobs:
           node-version: '18.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
+      - run: npm run build
       - run: npm publish --access=public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Including the build step would integrate the frontend build into the package on the npm registry, which should resolve the UI error that occurs when users follow the installation instructions.