### PR TITLE
chore: automatically increment version in package.json on new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,60 +1,91 @@
-# ---
-# name: Release
+---
+name: Release
 
-# on:
-#   workflow_dispatch:
-#   push:
-#     branches:
-#       - main
-#     paths:
-#       - 'src/**'
-#       - 'test/**'
-#       - 'scripts/**'
-#       - 'public/**'
-#       - 'packages/**'
-#       - 'package.json'
-#       - 'package-lock.json'
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'test/**'
+      - 'scripts/**'
+      - 'public/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
 
-# permissions:
-#   contents: read
+permissions:
+  contents: read
 
-# jobs:
-#   create_github_release:
-#     outputs:
-#       full-tag: ${{ steps.release-drafter.outputs.tag_name }}
-#       short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
-#       body: ${{ steps.release-drafter.outputs.body }}
-#     runs-on: ubuntu-latest
-#     permissions:
-#       contents: write
-#       pull-requests: read
-#     steps:
-#       - uses: release-drafter/release-drafter@v6
-#         id: release-drafter
-#         env:
-#           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#         with:
-#           publish: true
-#       - name: Get the short tag
-#         id: get_tag_name
-#         run: |
-#           short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
-#           echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
-#   create_npm_release:
-#     needs: create_github_release
-#     runs-on: ubuntu-latest
-#     permissions:
-#       packages: write
-#     env:
-#       REGISTRY: ghcr.io
-#       IMAGE_NAME: ${{ github.repository }}
-#     steps:
-#       - uses: actions/checkout@8459bc0 # v4
-#       - uses: actions/setup-node@c2ac33f # v4, Setup .npmrc file to publish to npm
-#         with:
-#           node-version: '18.x'
-#           registry-url: 'https://registry.npmjs.org'
-#       - run: npm ci
-#       - run: npm publish --access=public
-#         env:
-#           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+jobs:
+  create_github_release:
+    outputs:
+      full-tag: ${{ steps.release-drafter.outputs.tag_name }}
+      short-tag: ${{ steps.get_tag_name.outputs.SHORT_TAG }}
+      body: ${{ steps.release-drafter.outputs.body }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: read
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        id: release-drafter
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          publish: true
+      - name: Get the short tag
+        id: get_tag_name
+        run: |
+          short_tag=$(echo ${{ steps.release-drafter.outputs.tag_name }} | cut -d. -f1)
+          echo "SHORT_TAG=$short_tag" >> $GITHUB_OUTPUT
+  create_npm_release:
+    needs: create_github_release
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+    steps:
+      - uses: actions/checkout@8459bc0 # v4
+      - uses: actions/setup-node@c2ac33f # v4, Setup .npmrc file to publish to npm
+        with:
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm publish --access=public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  update_version:
+    needs: create_npm_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        id: release-drafter
+        with:
+          publish: true
+      - name: Extract version
+        id: extract_version
+        run: |
+          echo "${{ steps.release-drafter.outputs.tag_name }}" | sed 's/^v//' > version.txt
+          echo ::set-output name=version::$(cat version.txt)
+      - name: Update package.json and package-lock version
+        run : |
+          jq --arg version "${{ steps.extract_version.outputs.version }}" '.version = $version' package.json > package_tmp.json && mv package_tmp.json package.json
+          jq --arg version "${{ steps.extract_version.outputs.version }}" '.version = $version' package-lock.json > package_lock_tmp.json && mv package_lock_tmp.json  package-lock.json
+      - name: Update docusaurus.config.js version
+        run: |
+          sed -i "s/version: '.*'/version: '${{ steps.extract_version.outputs.version }}'/" website/docusaurus.config.js
+      - name : Commit version change
+        run : |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git config --global push.default current
+          git add package.json package-lock.json 
+          git commit -m "chore: update version to ${{ steps.extract_version.outputs.version }}" 
+      - name: Push Changes 
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
     needs: create_npm_release
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@8459bc0 # v4
       - uses: release-drafter/release-drafter@v6
         id: release-drafter
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .data
 logs
 *.log
+.idea
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*


### PR DESCRIPTION
This PR attempts to resolve this issue  [Automatically increment version in package.json on new release 📦](https://github.com/finos/git-proxy/issues/557) .  The PR aims at automating the  update off the version in pacakge.json 

1. A new step has been added to extract the version number from the draft release. this version number is then used in subsequent steps to update the package.json
2. The extracted version number is used to update the package.json,package-lock.json and the docusaurus.config.js
3. after update the update a commit is pushed back to the repository 

