### PR TITLE
feat: add google analytics docusaurus plugin

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -135,6 +135,10 @@ module.exports = {
         theme: {
           customCss: require.resolve('./src/css/custom.css'),
         },
+        gtag: {
+          trackingID: "G-BV8KZH4G0M",
+          anonymizeIP: true,
+        }
       },
     ],
   ],

--- a/website/package.json
+++ b/website/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
+    "@docusaurus/plugin-google-gtag": "^3.0.0",
     "axios": "^1.7.2",
     "classnames": "^2.2.6",
     "clsx": "^2.0.0",


### PR DESCRIPTION
FINOS marketing team would like to add Google Analytics to https://git-proxy.finos.org/