### PR TITLE
fix: #669-ui/docs: clone component is undefined when running as a server

### DIFF
--- a/src/ui/views/RepoList/Components/RepoOverview.jsx
+++ b/src/ui/views/RepoList/Components/RepoOverview.jsx
@@ -585,7 +585,7 @@ export default function Repositories(props) {
   };
 
   const { project: org, name } = props?.data || {};
-  const cloneURL = `${import.meta.env.VITE_SERVER_URI}/${org}/${name}.git`;
+  const cloneURL = `${window.location.origin.toString()}/${org}/${name}.git`;
 
   return (
     <TableRow>


### PR DESCRIPTION
closes #669 

Instead of getting the origin from the vite environment variables, the component will now get the origin from browsers 
JavaScript location API and It won't show undefined in the server