### PR TITLE
chore: Add repository in package.json files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
   ],
   "author": "Paul Groves",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/finos/git-proxy"
+  },
   "dependencies": {
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "4.11.3",

--- a/packages/git-proxy-cli/package.json
+++ b/packages/git-proxy-cli/package.json
@@ -18,5 +18,10 @@
     "test-coverage-ci": "nyc --reporter=lcovonly --reporter=text --reporter=html npm run test"
   },
   "author": "Miklos Sagi",
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/finos/git-proxy",
+    "path": "packages/git-proxy-cli"
+  }
 }

--- a/packages/git-proxy-notify-hello/package.json
+++ b/packages/git-proxy-notify-hello/package.json
@@ -7,6 +7,11 @@
   },
   "author": "Thomas Cooper",
   "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/finos/git-proxy",
+    "path": "packages/git-proxy-notify-hello"
+  },
   "dependencies": {
     "@finos/git-proxy": "file:../.."
   }


### PR DESCRIPTION
Add 'repository' field [1] to various package.json to create a link between release artifacts and corresponding code in the project's repository. This helps SBOM tools such as ORT [2] to create better SBOMs and reduces amount of code that needs to scanned and reviewed for license compliance.

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository
[2]: https://github.com/oss-review-toolkit/ort


Bit of context: I am working on generating high quality SBOM (e.g with licenses clarified till file level) for eventually all FINOS projects so they can be easier adopted and used in high compliance environments where SBOMs are or will be a  "must-have". Don't want to burden maintainers with what's a FOSS consumer topic imo so went I see things causing SBOM issue you will see me shoot in PR to try to fix them.