### PR TITLE
feat: allow for providing an alternative domain for the proxy

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,2 +1,1 @@
 VITE_API_URI=http://localhost:8080
-VITE_SERVER_URI=http://localhost:8000

--- a/config.schema.json
+++ b/config.schema.json
@@ -20,6 +20,10 @@
       "description": "Customisable questions to add to attestation form",
       "type": "object"
     },
+    "domains": {
+      "description": "Provide domains to use alternative to the defaults",
+      "type": "object"
+    },
     "privateOrganizations": {
       "description": "Pattern searches for listed private organizations are disabled",
       "type": "array"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,78 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1728979988,
+        "narHash": "sha256-GBJRnbFLDg0y7ridWJHAP4Nn7oss50/VNgqoXaf/RVk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7881fbfd2e3ed1dfa315fca889b2cfd94be39337",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,23 @@
+{
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.flake-compat = { url = "github:edolstra/flake-compat"; flake = false; };
+
+  outputs = { self, nixpkgs, flake-utils, ... }@inputs:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        nodejs = pkgs.nodejs_20;
+      in
+      {
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              nodejs
+              json-schema-for-humans
+            ];
+          };
+        };
+      }
+    );
+}

--- a/proxy.config.json
+++ b/proxy.config.json
@@ -92,6 +92,7 @@
       }
     ]
   },
+  "domains": {},
   "privateOrganizations": [],
   "urlShortener": "",
   "contactEmail": "",

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,6 @@
+let
+  inherit ((builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.flake-compat.locked) rev narHash;
+in
+(import
+  (fetchTarball { url = "https://github.com/edolstra/flake-compat/archive/${rev}.tar.gz"; sha256 = narHash; })
+  { src = ./.; }).shellNix

--- a/src/config/index.js
+++ b/src/config/index.js
@@ -23,6 +23,7 @@ let _privateOrganizations = defaultSettings.privateOrganizations;
 let _urlShortener = defaultSettings.urlShortener;
 let _contactEmail = defaultSettings.contactEmail;
 let _csrfProtection = defaultSettings.csrfProtection;
+let _domains = defaultSettings.domains;
 
 // Get configured proxy URL
 const getProxyUrl = () => {
@@ -180,6 +181,13 @@ const getSSLCertPath = () => {
   return _sslCertPath;
 };
 
+const getDomains = () => {
+  if (_userSettings && _userSettings.domains) {
+    _domains = _userSettings.domains;
+  }
+  return _domains;
+};
+
 exports.getAPIs = getAPIs;
 exports.getProxyUrl = getProxyUrl;
 exports.getAuthorisedList = getAuthorisedList;
@@ -197,3 +205,4 @@ exports.getContactEmail = getContactEmail;
 exports.getCSRFProtection = getCSRFProtection;
 exports.getSSLKeyPath = getSSLKeyPath;
 exports.getSSLCertPath = getSSLCertPath;
+exports.getDomains = getDomains;

--- a/src/service/proxyURL.js
+++ b/src/service/proxyURL.js
@@ -1,0 +1,13 @@
+const { GIT_PROXY_SERVER_PORT: PROXY_HTTP_PORT, GIT_PROXY_UI_PORT: UI_PORT } =
+  require('../config/env').Vars;
+const config = require('../config');
+
+module.exports = {
+  getProxyURL: (req) => {
+    const defaultURL = `${req.protocol}://${req.headers.host}`.replace(
+      `:${UI_PORT}`,
+      `:${PROXY_HTTP_PORT}`,
+    );
+    return config.getDomains().proxy ?? defaultURL;
+  },
+};

--- a/src/service/routes/push.js
+++ b/src/service/routes/push.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const router = new express.Router();
 const db = require('../../db');
+const { getProxyURL } = require('../proxyURL');
 
 router.get('/', async (req, res) => {
+  const proxyURL = getProxyURL(req);
   const query = {
     type: 'push',
   };
@@ -18,7 +20,8 @@ router.get('/', async (req, res) => {
     query[k] = v;
   }
 
-  res.send(await db.getPushes(query));
+  const qd = await db.getPushes(query);
+  res.send(qd.map((d) => ({ ...d, proxyURL })));
 });
 
 router.get('/:id', async (req, res) => {

--- a/src/service/routes/repo.js
+++ b/src/service/routes/repo.js
@@ -1,8 +1,10 @@
 const express = require('express');
 const router = new express.Router();
 const db = require('../../db');
+const { getProxyURL } = require('../proxyURL');
 
 router.get('/', async (req, res) => {
+  const proxyURL = getProxyURL(req);
   const query = {
     type: 'push',
   };
@@ -18,7 +20,8 @@ router.get('/', async (req, res) => {
     query[k] = v;
   }
 
-  res.send(await db.getRepos(query));
+  const qd = await db.getRepos(query);
+  res.send(qd.map((d) => ({ ...d, proxyURL })));
 });
 
 router.get('/:name', async (req, res) => {

--- a/src/ui/views/RepoDetails/RepoDetails.jsx
+++ b/src/ui/views/RepoDetails/RepoDetails.jsx
@@ -59,8 +59,8 @@ export default function RepoDetails() {
   if (isLoading) return <div>Loading...</div>;
   if (isError) return <div>Something went wrong ...</div>;
 
-  const { project: org, name } = data || {};
-  const cloneURL = `${import.meta.env.VITE_SERVER_URI}/${org}/${name}.git`;
+  const { project: org, name, proxyURL } = data || {};
+  const cloneURL = `${proxyURL}/${org}/${name}.git`;
 
   return (
     <GridContainer>

--- a/src/ui/views/RepoList/Components/RepoOverview.jsx
+++ b/src/ui/views/RepoList/Components/RepoOverview.jsx
@@ -584,8 +584,8 @@ export default function Repositories(props) {
       });
   };
 
-  const { project: org, name } = props?.data || {};
-  const cloneURL = `${window.location.origin.toString()}/${org}/${name}.git`;
+  const { project: org, name, proxyURL } = props?.data || {};
+  const cloneURL = `${proxyURL}/${org}/${name}.git`;
 
   return (
     <TableRow>

--- a/website/docs/configuration/reference.mdx
+++ b/website/docs/configuration/reference.mdx
@@ -16,7 +16,171 @@ description: JSON schema reference documentation for GitProxy
 **Description:** Configuration for customizing git-proxy
 
 <details>
-<summary><strong> <a name="authorisedList"></a>1. [Optional] Property GitProxy configuration file > authorisedList</strong>  </summary>
+<summary>
+<strong> <a name="proxyUrl"></a>1. [Optional] Property GitProxy configuration file > proxyUrl</strong>  </summary>
+<blockquote>
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="cookieSecret"></a>2. [Optional] Property GitProxy configuration file > cookieSecret</strong>  </summary>
+<blockquote>
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="sessionMaxAgeHours"></a>3. [Optional] Property GitProxy configuration file > sessionMaxAgeHours</strong>  </summary>
+<blockquote>
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `number` |
+| **Required** | No       |
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="api"></a>4. [Optional] Property GitProxy configuration file > api</strong>  </summary>
+<blockquote>
+
+|                           |                                                                           |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                  |
+| **Required**              | No                                                                        |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+
+**Description:** Third party APIs
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="commitConfig"></a>5. [Optional] Property GitProxy configuration file > commitConfig</strong>  </summary>
+<blockquote>
+
+|                           |                                                                           |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                  |
+| **Required**              | No                                                                        |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+
+**Description:** Enforce rules and patterns on commits including e-mail and message
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="attestationConfig"></a>6. [Optional] Property GitProxy configuration file > attestationConfig</strong>  </summary>
+<blockquote>
+
+|                           |                                                                           |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                  |
+| **Required**              | No                                                                        |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+
+**Description:** Customisable questions to add to attestation form
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="domains"></a>7. [Optional] Property GitProxy configuration file > domains</strong>  </summary>
+<blockquote>
+
+|                           |                                                                           |
+| ------------------------- | ------------------------------------------------------------------------- |
+| **Type**                  | `object`                                                                  |
+| **Required**              | No                                                                        |
+| **Additional properties** | [[Any type: allowed]](# "Additional Properties of any type are allowed.") |
+
+**Description:** Provide domains to use alternative to the defaults
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="privateOrganizations"></a>8. [Optional] Property GitProxy configuration file > privateOrganizations</strong>  </summary>
+<blockquote>
+
+|              |         |
+| ------------ | ------- |
+| **Type**     | `array` |
+| **Required** | No      |
+
+**Description:** Pattern searches for listed private organizations are disabled
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="urlShortener"></a>9. [Optional] Property GitProxy configuration file > urlShortener</strong>  </summary>
+<blockquote>
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Customisable URL shortener to share in proxy responses and warnings
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="contactEmail"></a>10. [Optional] Property GitProxy configuration file > contactEmail</strong>  </summary>
+<blockquote>
+
+|              |          |
+| ------------ | -------- |
+| **Type**     | `string` |
+| **Required** | No       |
+
+**Description:** Customisable e-mail address to share in proxy responses and warnings
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="csrfProtection"></a>11. [Optional] Property GitProxy configuration file > csrfProtection</strong>  </summary>
+<blockquote>
+
+|              |           |
+| ------------ | --------- |
+| **Type**     | `boolean` |
+| **Required** | No        |
+
+**Description:** Flag to enable CSRF protections for UI
+
+</blockquote>
+</details>
+
+<details>
+<summary>
+<strong> <a name="authorisedList"></a>12. [Optional] Property GitProxy configuration file > authorisedList</strong>  </summary>
 <blockquote>
 
 |              |         |
@@ -30,7 +194,7 @@ description: JSON schema reference documentation for GitProxy
 | --------------------------------------- | ----------- |
 | [authorisedRepo](#authorisedList_items) | -           |
 
-### <a name="autogenerated_heading_2"></a>1.1. GitProxy configuration file > authorisedList > authorisedRepo
+### <a name="autogenerated_heading_2"></a>12.1. GitProxy configuration file > authorisedList > authorisedRepo
 
 |                           |                                                                           |
 | ------------------------- | ------------------------------------------------------------------------- |
@@ -40,7 +204,8 @@ description: JSON schema reference documentation for GitProxy
 | **Defined in**            | #/definitions/authorisedRepo                                              |
 
 <details>
-<summary><strong> <a name="authorisedList_items_project"></a>1.1.1. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > project</strong>  </summary>
+<summary>
+<strong> <a name="authorisedList_items_project"></a>12.1.1. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > project</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -52,7 +217,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="authorisedList_items_name"></a>1.1.2. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > name</strong>  </summary>
+<summary>
+<strong> <a name="authorisedList_items_name"></a>12.1.2. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > name</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -64,7 +230,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="authorisedList_items_url"></a>1.1.3. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > url</strong>  </summary>
+<summary>
+<strong> <a name="authorisedList_items_url"></a>12.1.3. [Required] Property GitProxy configuration file > authorisedList > authorisedList items > url</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -79,7 +246,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="sink"></a>2. [Optional] Property GitProxy configuration file > sink</strong>  </summary>
+<summary>
+<strong> <a name="sink"></a>13. [Optional] Property GitProxy configuration file > sink</strong>  </summary>
 <blockquote>
 
 |              |         |
@@ -93,7 +261,7 @@ description: JSON schema reference documentation for GitProxy
 | ------------------------------- | ----------- |
 | [database](#sink_items)         | -           |
 
-### <a name="autogenerated_heading_3"></a>2.1. GitProxy configuration file > sink > database
+### <a name="autogenerated_heading_3"></a>13.1. GitProxy configuration file > sink > database
 
 |                           |                                                                           |
 | ------------------------- | ------------------------------------------------------------------------- |
@@ -103,7 +271,8 @@ description: JSON schema reference documentation for GitProxy
 | **Defined in**            | #/definitions/database                                                    |
 
 <details>
-<summary><strong> <a name="sink_items_type"></a>2.1.1. [Required] Property GitProxy configuration file > sink > sink items > type</strong>  </summary>
+<summary>
+<strong> <a name="sink_items_type"></a>13.1.1. [Required] Property GitProxy configuration file > sink > sink items > type</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -115,7 +284,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="sink_items_enabled"></a>2.1.2. [Required] Property GitProxy configuration file > sink > sink items > enabled</strong>  </summary>
+<summary>
+<strong> <a name="sink_items_enabled"></a>13.1.2. [Required] Property GitProxy configuration file > sink > sink items > enabled</strong>  </summary>
 <blockquote>
 
 |              |           |
@@ -127,7 +297,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="sink_items_connectionString"></a>2.1.3. [Optional] Property GitProxy configuration file > sink > sink items > connectionString</strong>  </summary>
+<summary>
+<strong> <a name="sink_items_connectionString"></a>13.1.3. [Optional] Property GitProxy configuration file > sink > sink items > connectionString</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -139,7 +310,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="sink_items_options"></a>2.1.4. [Optional] Property GitProxy configuration file > sink > sink items > options</strong>  </summary>
+<summary>
+<strong> <a name="sink_items_options"></a>13.1.4. [Optional] Property GitProxy configuration file > sink > sink items > options</strong>  </summary>
 <blockquote>
 
 |                           |                                                                           |
@@ -152,7 +324,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="sink_items_params"></a>2.1.5. [Optional] Property GitProxy configuration file > sink > sink items > params</strong>  </summary>
+<summary>
+<strong> <a name="sink_items_params"></a>13.1.5. [Optional] Property GitProxy configuration file > sink > sink items > params</strong>  </summary>
 <blockquote>
 
 |                           |                                                                           |
@@ -168,7 +341,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="authentication"></a>3. [Optional] Property GitProxy configuration file > authentication</strong>  </summary>
+<summary>
+<strong> <a name="authentication"></a>14. [Optional] Property GitProxy configuration file > authentication</strong>  </summary>
 <blockquote>
 
 |              |         |
@@ -182,7 +356,7 @@ description: JSON schema reference documentation for GitProxy
 | --------------------------------------- | ----------- |
 | [authentication](#authentication_items) | -           |
 
-### <a name="autogenerated_heading_4"></a>3.1. GitProxy configuration file > authentication > authentication
+### <a name="autogenerated_heading_4"></a>14.1. GitProxy configuration file > authentication > authentication
 
 |                           |                                                                           |
 | ------------------------- | ------------------------------------------------------------------------- |
@@ -192,7 +366,8 @@ description: JSON schema reference documentation for GitProxy
 | **Defined in**            | #/definitions/authentication                                              |
 
 <details>
-<summary><strong> <a name="authentication_items_type"></a>3.1.1. [Required] Property GitProxy configuration file > authentication > authentication items > type</strong>  </summary>
+<summary>
+<strong> <a name="authentication_items_type"></a>14.1.1. [Required] Property GitProxy configuration file > authentication > authentication items > type</strong>  </summary>
 <blockquote>
 
 |              |          |
@@ -204,7 +379,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="authentication_items_enabled"></a>3.1.2. [Required] Property GitProxy configuration file > authentication > authentication items > enabled</strong>  </summary>
+<summary>
+<strong> <a name="authentication_items_enabled"></a>14.1.2. [Required] Property GitProxy configuration file > authentication > authentication items > enabled</strong>  </summary>
 <blockquote>
 
 |              |           |
@@ -216,7 +392,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="authentication_items_options"></a>3.1.3. [Optional] Property GitProxy configuration file > authentication > authentication items > options</strong>  </summary>
+<summary>
+<strong> <a name="authentication_items_options"></a>14.1.3. [Optional] Property GitProxy configuration file > authentication > authentication items > options</strong>  </summary>
 <blockquote>
 
 |                           |                                                                           |
@@ -232,7 +409,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="tempPassword"></a>4. [Optional] Property GitProxy configuration file > tempPassword</strong>  </summary>
+<summary>
+<strong> <a name="tempPassword"></a>15. [Optional] Property GitProxy configuration file > tempPassword</strong>  </summary>
 <blockquote>
 
 |                           |                                                                           |
@@ -244,7 +422,8 @@ description: JSON schema reference documentation for GitProxy
 **Description:** Toggle the generation of temporary password for git-proxy admin user
 
 <details>
-<summary><strong> <a name="tempPassword_sendEmail"></a>4.1. [Optional] Property GitProxy configuration file > tempPassword > sendEmail</strong>  </summary>
+<summary>
+<strong> <a name="tempPassword_sendEmail"></a>15.1. [Optional] Property GitProxy configuration file > tempPassword > sendEmail</strong>  </summary>
 <blockquote>
 
 |              |           |
@@ -256,7 +435,8 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 <details>
-<summary><strong> <a name="tempPassword_emailConfig"></a>4.2. [Optional] Property GitProxy configuration file > tempPassword > emailConfig</strong>  </summary>
+<summary>
+<strong> <a name="tempPassword_emailConfig"></a>15.2. [Optional] Property GitProxy configuration file > tempPassword > emailConfig</strong>  </summary>
 <blockquote>
 
 |                           |                                                                           |
@@ -274,4 +454,4 @@ description: JSON schema reference documentation for GitProxy
 </details>
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2023-12-10 at 15:42:45 -0500
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2024-10-17 at 12:14:47 +0100


### PR DESCRIPTION
- **chore: add flake file for providing a development environment**
  - easy method of getting development dependencies required outside of npm
- **feat: allow for providing an alternative domain for the proxy**
  - Have the service report back the proxyURL for each project, rather than
  - being embedded inside the frontend bundle.
  - Concequence is duplicating some data but very minor and allows for us to serve
  - different projects from different proxies in the future.
  - Removed unused vite env var, added method to pull service's current path and substitute
  - in the http proxy port. Works for local dev, should maintain current behaviour.
  - Custom domain can be applied via optional config.
  - New config value added to the config schema.
  - Config schema documentation has been regenerated (including some other absent items).
