### PR TITLE
fix: move creation of remote folder into function call

### DIFF
--- a/src/proxy/processors/push-action/pullRemote.js
+++ b/src/proxy/processors/push-action/pullRemote.js
@@ -3,10 +3,6 @@ const Step = require('../../actions').Step;
 const fs = require('fs');
 const dir = './.remote';
 
-if (!fs.existsSync(dir)) {
-  fs.mkdirSync(dir);
-}
-
 const exec = async (req, action) => {
   const step = new Step('pullRemote');
 
@@ -14,6 +10,10 @@ const exec = async (req, action) => {
     action.proxyGitPath = `${dir}/${action.timestamp}`;
 
     step.log(`Creating folder ${action.proxyGitPath}`);
+
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir);
+    }
 
     if (!fs.existsSync(action.proxyGitPath)) {
       fs.mkdirSync(action.proxyGitPath, '0777', true);


### PR DESCRIPTION
When `pullRemote.js` is imported for the first time, the `.remote` folder is created. At the end of the chain the `clearBareClone.js` function purges the `.remote` folder. This change ensures that the `.remote` folder can be re-created on subsequent pushes by introducing the `mkdirSync()` call into the `exec()` function which is exported and called in the chain 👍 