### PR TITLE
fix: update peer dependency requirement for @finos/git-proxy to >=1.3.5-alpha.5

### DIFF
--- a/plugins/git-proxy-plugin-samples/package.json
+++ b/plugins/git-proxy-plugin-samples/package.json
@@ -16,6 +16,6 @@
     "express": "^4.18.2"
   },
   "peerDependencies": {
-    "@finos/git-proxy": "1.3.5-alpha.5"
+    "@finos/git-proxy": ">=1.3.5-alpha.5"
   }
 }


### PR DESCRIPTION
Updated the peer dependency on @finos/git-proxy from "1.3.5-alpha.5" to ">=1.3.5-alpha.5" in the git-proxy-plugin-samples package.json file. 

This change allows compatibility with newer versions of @finos/git-proxy, including 1.4.0 and beyond. By loosening the version constraint, users can run the plugin with both the specified alpha version and future releases, providing greater flexibility for installation and compatibility.

This commit addresses peer dependency warnings and errors during installation when newer versions of git-proxy are present.

Team:
Aryan Konde:
aryankonde
aryankonde114@gmail.com

Suyash Dongre:
Suyashd999
suyashd999@gmail.com

Khushi Bora:
snowflakes2499
khushibora249@gmail.com