### PR TITLE
fix: Update pullRemote.js to set appropriate directory permissions

### DIFF
--- a/src/proxy/processors/push-action/pullRemote.js
+++ b/src/proxy/processors/push-action/pullRemote.js
@@ -16,7 +16,7 @@ const exec = async (req, action) => {
     }
 
     if (!fs.existsSync(action.proxyGitPath)) {
-      fs.mkdirSync(action.proxyGitPath, '0777', true);
+      fs.mkdirSync(action.proxyGitPath, '0755', true);
     }
 
     const cmd = `git clone ${action.url} --bare`;


### PR DESCRIPTION
This PR modifies the directory creation permissions in the pullRemote function of pullRemote.js. 

Previously, the function was setting directory permissions to 0777 (full read, write, and execute permissions for user, group, and others). This approach is not aligned with best practices for security, particularly in secure environments such as OpenShift, where overly permissive settings can lead to vulnerabilities.

The updated code now sets the permissions to 0755 (read, write, and execute for the user; read and execute for group and others). This change enhances security by restricting write access to the owner only while still allowing necessary read and execute permissions.