### PR TITLE
refactor: remove exports from package.json and adjust imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,11 +23,6 @@
     "git-proxy": "./index.js",
     "git-proxy-all": "concurrently 'npm run server' 'npm run client'"
   },
-  "exports": {
-    "./plugin": "./src/plugin.js",
-    "./proxy/actions": "./src/proxy/actions/index.js",
-    "./src/config/env": "./src/config/env.js"
-  },
   "workspaces": [
     "./packages/git-proxy-cli"
   ],

--- a/plugins/git-proxy-plugin-samples/example.cjs
+++ b/plugins/git-proxy-plugin-samples/example.cjs
@@ -4,8 +4,8 @@
  */
 
 // Peer dependencies; its expected that these deps exist on Node module path if you've installed @finos/git-proxy
-const { PushActionPlugin } = require('@finos/git-proxy/plugin');
-const { Step } = require('@finos/git-proxy/proxy/actions');
+const { PushActionPlugin } = require('@finos/git-proxy/src/plugin');
+const { Step } = require('@finos/git-proxy/src/proxy/actions');
 'use strict';
 
 /**

--- a/plugins/git-proxy-plugin-samples/index.js
+++ b/plugins/git-proxy-plugin-samples/index.js
@@ -4,8 +4,8 @@
  */
 
 // Peer dependencies; its expected that these deps exist on Node module path if you've installed @finos/git-proxy
-import { PullActionPlugin } from "@finos/git-proxy/plugin";
-import { Step } from "@finos/git-proxy/proxy/actions";
+import { PullActionPlugin } from "@finos/git-proxy/src/plugin";
+import { Step } from "@finos/git-proxy/src/proxy/actions";
 
 class RunOnPullPlugin extends PullActionPlugin {
   constructor() {

--- a/test/fixtures/test-package/default-export.js
+++ b/test/fixtures/test-package/default-export.js
@@ -1,4 +1,4 @@
-const { PushActionPlugin } = require('@osp0/finos-git-proxy/plugin');
+const { PushActionPlugin } = require('@finos/git-proxy/src/plugin');
 
 // test default export
 module.exports = new PushActionPlugin(async (req, action) => {

--- a/test/fixtures/test-package/multiple-export.js
+++ b/test/fixtures/test-package/multiple-export.js
@@ -1,4 +1,4 @@
-const { PushActionPlugin, PullActionPlugin } = require('@osp0/finos-git-proxy/plugin');
+const { PushActionPlugin, PullActionPlugin } = require('@finos/git-proxy/src/plugin');
 
 
 module.exports = {

--- a/test/fixtures/test-package/package.json
+++ b/test/fixtures/test-package/package.json
@@ -2,6 +2,6 @@
   "name": "test-package",
   "version": "0.0.0",
   "dependencies": {
-    "@osp0/finos-git-proxy": "file:../../.."
+    "@finos/git-proxy": "file:../../.."
   }
 }

--- a/test/fixtures/test-package/subclass.js
+++ b/test/fixtures/test-package/subclass.js
@@ -1,4 +1,4 @@
-const { PushActionPlugin } = require('@osp0/finos-git-proxy/plugin');
+const { PushActionPlugin } = require('@finos/git-proxy/src/plugin');
 
 class DummyPlugin extends PushActionPlugin {
   constructor(exec) {

--- a/website/docs/development/plugins.mdx
+++ b/website/docs/development/plugins.mdx
@@ -124,9 +124,9 @@ Loaded plugin: FooPlugin
 
 To develop a new plugin, you must add `@finos/git-proxy` as a [peer dependency](https://docs.npmjs.com/cli/v10/configuring-npm/package-json#peerdependencies). The main app (also known as the "host application") exports the following extension points:
 
-- `@finos/git-proxy/plugin/PushActionPlugin`: execute as an action in the proxy chain during a `git push`
-- `@finos/git-proxy/plugin/PullActionPlugin`: execute as an action in the proxy chain during a `git fetch`
-- `@finos/git-proxy/proxy/actions/Step` and `@finos/git-proxy/proxy/actions/Action`: internal classes which act as carriers for `git` state during proxying. Plugins should modify the passed in `action` for affecting any global state of the git operation and add its own custom `Step` object to capture the plugin's own internal state (logs, errored/blocked status, etc.)
+- `@finos/git-proxy/src/plugin/PushActionPlugin`: execute as an action in the proxy chain during a `git push`
+- `@finos/git-proxy/src/plugin/PullActionPlugin`: execute as an action in the proxy chain during a `git fetch`
+- `@finos/git-proxy/src/proxy/actions/Step` and `@finos/git-proxy/src/proxy/actions/Action`: internal classes which act as carriers for `git` state during proxying. Plugins should modify the passed in `action` for affecting any global state of the git operation and add its own custom `Step` object to capture the plugin's own internal state (logs, errored/blocked status, etc.)
 
 GitProxy will load your plugin only if it extends one of the two plugin classes above. It is also important that your package has [`exports`](https://nodejs.org/api/packages.html#exports) defined for the plugin loader to properly load your module(s).
 
@@ -135,7 +135,7 @@ Please see the [sample plugin package included in the repo](https://github.com/f
 If your plugin relies on custom state, it is recommended to create subclasses in the following manner:
 
 ```javascript
-import { PushActionPlugin } from "@finos/git-proxy/plugin";
+import { PushActionPlugin } from "@finos/git-proxy/src/plugin";
 
 class FooPlugin extends PushActionPlugin {
   constructor() {
@@ -189,8 +189,8 @@ $ npm install --save-peer @finos/git-proxy@latest
 
 `bar.js`
 ```javascript
-import { PushActionPlugin } from "@finos/git-proxy/plugin";
-import { Step } from "@finos/git-proxy/proxy/actions";
+import { PushActionPlugin } from "@finos/git-proxy/src/plugin";
+import { Step } from "@finos/git-proxy/src/proxy/actions";
 
 //Note: Only use a default export if you do not rely on any state. Otherwise, create a sub-class of [Push/Pull]ActionPlugin
 export default new PushActionPlugin(function(req, action) {


### PR DESCRIPTION
Exports makes it hard to access other paths in the project
Until we arrive on stable interfaces to access other parts of git-proxy
removing exports would be helpful.
Import paths have been adjusted slightly for plugins and the docs for
plugins due to the exports aliases being a bit different.
