### PR TITLE
refactor(experimental): abstract data layer

### DIFF
--- a/experimental/license-inventory/package-lock.json
+++ b/experimental/license-inventory/package-lock.json
@@ -31,6 +31,7 @@
         "@types/express": "^5.0.0",
         "@types/mongoose": "^5.11.97",
         "@types/node": "^22.10.1",
+        "@types/semver": "^7.5.8",
         "@types/supertest": "^6.0.2",
         "@typescript-eslint/eslint-plugin": "^8.17.0",
         "@typescript-eslint/parser": "^8.17.0",
@@ -3711,6 +3712,13 @@
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.8.tgz",
+      "integrity": "sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/experimental/license-inventory/package.json
+++ b/experimental/license-inventory/package.json
@@ -38,6 +38,7 @@
     "@types/express": "^5.0.0",
     "@types/mongoose": "^5.11.97",
     "@types/node": "^22.10.1",
+    "@types/semver": "^7.5.8",
     "@types/supertest": "^6.0.2",
     "@typescript-eslint/eslint-plugin": "^8.17.0",
     "@typescript-eslint/parser": "^8.17.0",

--- a/experimental/license-inventory/src/app.ts
+++ b/experimental/license-inventory/src/app.ts
@@ -1,39 +1,42 @@
 import express from 'express';
 import { logger } from '@/logger';
-import apiRouter from '@/routes/api';
+import createApiRouter from '@/routes/api';
 import pinoHTTP from 'pino-http';
 import bodyParser from 'body-parser';
 import { rateLimit } from 'express-rate-limit';
 import helmet from 'helmet';
+import { LicenseDataService } from './services/data';
 // import lusca from 'lusca';
 
 // helmet and lusca comparison
 // https://github.com/krakenjs/lusca/issues/42#issuecomment-65093906
 // TODO: integrate lusca once added sessions/auth
 
-const app = express();
+const createApp = (lds: LicenseDataService) => {
+  const app = express();
 
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  limit: 100,
-  standardHeaders: 'draft-7',
-  legacyHeaders: false,
-  // in memory store
-});
+  const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000,
+    limit: 100,
+    standardHeaders: 'draft-7',
+    legacyHeaders: false,
+    // in memory store
+  });
 
-app.use(helmet());
-app.use(limiter);
-app.use(bodyParser.json());
-app.use(
-  pinoHTTP({
-    logger,
-    autoLogging: process.env.NODE_ENV === 'development',
-    // overrides core logger redaction
-    // please update in logger.ts
-    // redact: [],
-  }),
-);
+  app.use(helmet());
+  app.use(limiter);
+  app.use(bodyParser.json());
+  app.use(
+    pinoHTTP({
+      logger,
+      autoLogging: process.env.NODE_ENV === 'development',
+      // overrides core logger redaction
+      // please update in logger.ts
+      // redact: [],
+    }),
+  );
 
-app.use('/api', apiRouter);
-
-export { app };
+  app.use('/api', createApiRouter(lds));
+  return app;
+};
+export { createApp };

--- a/experimental/license-inventory/src/db/connect.ts
+++ b/experimental/license-inventory/src/db/connect.ts
@@ -1,10 +1,10 @@
 import { AsyncResult } from '@/types';
-import mongoose from 'mongoose';
+import mongoose, { type Mongoose } from 'mongoose';
 
-export const connectDB = async (dbURI: string): AsyncResult<void> => {
+export const connectDB = async (dbURI: string): AsyncResult<Mongoose> => {
   try {
-    await mongoose.connect(dbURI);
-    return { error: null, data: null };
+    const connection = await mongoose.connect(dbURI);
+    return { error: null, data: connection };
   } catch (e: unknown) {
     if (e instanceof Error) {
       return { error: e, data: null };

--- a/experimental/license-inventory/src/db/index.ts
+++ b/experimental/license-inventory/src/db/index.ts
@@ -1,0 +1,11 @@
+import type { Mongoose, Model } from 'mongoose';
+import { licenseSchema, type LicenseSchema } from './schemas/license/license';
+
+export class Database {
+  mongoose: Mongoose;
+  License: Model<LicenseSchema>;
+  constructor(mongoose: Mongoose) {
+    this.mongoose = mongoose;
+    this.License = mongoose.model<LicenseSchema>('License', licenseSchema);
+  }
+}

--- a/experimental/license-inventory/src/db/schemas/license/license.test.ts
+++ b/experimental/license-inventory/src/db/schemas/license/license.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
 import { License } from '@/db/collections';
-import { licenseValidation } from './license';
 import { v4 as uuidv4 } from 'uuid';
 
 // these tests require a mongodb instance
@@ -16,7 +15,7 @@ describeDB('license', () => {
 
     const insertedLicense = await License.findOne({ _id: _id });
     expect(insertedLicense).not.toBeNull();
-    expect(insertedLicense.name).toBe('hello');
+    expect(insertedLicense!.name).toBe('hello');
   });
 
   it('can insert a complex license', async () => {
@@ -37,30 +36,7 @@ describeDB('license', () => {
 
     const insertedLicense = await License.findOne({ _id: _id });
     expect(insertedLicense).not.toBeNull();
-    expect(insertedLicense.name).toBe('complex');
-    expect(insertedLicense.chooseALicenseInfo.permissions.commercialUse).toBe(true);
-  });
-
-  it('complex license conforms to output validation', async () => {
-    const _id = uuidv4();
-    await License.create({
-      _id,
-      name: 'complex2',
-      spdxID: 'sample2',
-      chooseALicenseInfo: {
-        permissions: {
-          commercialUse: true,
-        },
-        conditions: {
-          networkUseDisclose: false,
-        },
-      },
-    });
-
-    const insertedLicense = await (await License.findOne({ _id }).exec()).toJSON();
-    const { error, data } = licenseValidation.safeParse(insertedLicense);
-    expect(error).toBeUndefined();
-    expect(data.id).toBe(_id);
-    expect(!Object.keys(data).includes('_id'));
+    expect(insertedLicense!.name).toBe('complex');
+    expect(insertedLicense!.chooseALicenseInfo?.permissions?.commercialUse).toBe(true);
   });
 });

--- a/experimental/license-inventory/src/db/schemas/license/license.ts
+++ b/experimental/license-inventory/src/db/schemas/license/license.ts
@@ -24,27 +24,6 @@ export const licenseSchema = new Schema<LicenseSchema>(
   {
     // automatic createdAt updatedAt
     timestamps: true,
-    toObject: {
-      virtuals: true,
-      versionKey: false,
-      transform: (doc, ret) => {
-        delete ret._id;
-      },
-    },
-    toJSON: {
-      virtuals: true,
-      versionKey: false,
-      transform: (doc, ret) => {
-        delete ret._id;
-      },
-    },
-    virtuals: {
-      id: {
-        get() {
-          return this._id.toString();
-        },
-      },
-    },
   },
 );
 

--- a/experimental/license-inventory/src/env.ts
+++ b/experimental/license-inventory/src/env.ts
@@ -1,9 +1,11 @@
 import { z } from 'zod';
 
-const envSchema = z.object({
-  PORT: z.coerce.number().default(3000),
-  MONGO_URI: z.string(),
-});
+const envSchema = z
+  .object({
+    PORT: z.coerce.number().default(3000),
+    MONGO_URI: z.string(),
+  })
+  .required();
 
 const { error, data: env } = envSchema.safeParse(process.env);
 if (error) {
@@ -11,4 +13,4 @@ if (error) {
   throw new Error('failed to validate');
 }
 
-export default env;
+export default env as z.infer<typeof envSchema>;

--- a/experimental/license-inventory/src/routes/api/index.ts
+++ b/experimental/license-inventory/src/routes/api/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
-import v0Router from './v0';
-const router = express.Router();
+import createV0Router from './v0';
+import { LicenseDataService } from '@/services/data';
 
-router.use('/v0', v0Router);
+const createRouter = (lds: LicenseDataService) => {
+  const router = express.Router();
 
-export default router;
+  router.use('/v0', createV0Router(lds));
+  return router;
+};
+
+export default createRouter;

--- a/experimental/license-inventory/src/routes/api/v0/index.ts
+++ b/experimental/license-inventory/src/routes/api/v0/index.ts
@@ -1,7 +1,12 @@
 import express from 'express';
-import licensesRouter from './licenses';
-const router = express.Router();
+import createLicensesRouter from './licenses';
+import { LicenseDataService } from '@/services/data';
 
-router.use('/licenses', licensesRouter);
+const createRouter = (lds: LicenseDataService) => {
+  const router = express.Router();
 
-export default router;
+  router.use('/licenses', createLicensesRouter(lds));
+  return router;
+};
+
+export default createRouter;

--- a/experimental/license-inventory/src/routes/api/v0/licenses.test.ts
+++ b/experimental/license-inventory/src/routes/api/v0/licenses.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, jest } from '@jest/globals';
 import request from 'supertest';
-import { License } from '@/db/collections';
-import { app } from '@/app';
+import { v4 as uuidv4 } from 'uuid';
+import { createApp } from '@/app';
+import { genMockLicenseDataService } from '@/test/mock/db';
 
 const basePath = '/api/v0/licenses';
 const genRoute = (p: string) => basePath + p;
@@ -13,11 +14,9 @@ describe(basePath, () => {
 
   describe('GET / - list', () => {
     it('no data', async () => {
-      const execMock = jest.fn(() => Promise.resolve([]));
-      jest.spyOn(License, 'find').mockReturnValueOnce({
-        exec: execMock,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      const mockLDS = genMockLicenseDataService();
+      mockLDS.list.mockResolvedValueOnce({ error: null, data: [] });
+      const app = createApp(mockLDS);
       const res = await request(app).get(genRoute('/')).expect('Content-Type', /json/).expect(200);
 
       expect(res.body).toEqual([]);
@@ -25,17 +24,56 @@ describe(basePath, () => {
 
     it('one entry', async () => {
       const inputData = {
-        id: 'test',
+        id: uuidv4(),
         name: 'test',
       };
-      const execMock = jest.fn(() => Promise.resolve([{ toJSON: async () => inputData }]));
-      jest.spyOn(License, 'find').mockReturnValueOnce({
-        exec: execMock,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      } as any);
+      const mockLDS = genMockLicenseDataService();
+      mockLDS.list.mockResolvedValueOnce({ error: null, data: [inputData] });
+      const app = createApp(mockLDS);
       const res = await request(app).get(genRoute('/')).expect('Content-Type', /json/).expect(200);
 
       expect(res.body).toEqual([inputData]);
+    });
+  });
+
+  describe(`GET /:id - read`, () => {
+    const testID = '157c0c6a-5c99-4298-9529-95816da2255a';
+    it('invalid id - not uuid', async () => {
+      const mockLDS = genMockLicenseDataService();
+      mockLDS.getByUUID.mockResolvedValueOnce({ error: null, data: null });
+      const app = createApp(mockLDS);
+      await request(app)
+        .get(genRoute('/' + 'apache-2_0'))
+        .expect('Content-Type', /json/)
+        .expect(500);
+    });
+
+    it('valid id - no data', async () => {
+      const mockLDS = genMockLicenseDataService();
+      mockLDS.getByUUID.mockResolvedValueOnce({ error: null, data: null });
+      const app = createApp(mockLDS);
+      const res = await request(app)
+        .get(genRoute('/' + testID))
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(res.body).toEqual({ license: null });
+    });
+
+    it('valid id - data', async () => {
+      const licenseData = {
+        id: testID,
+        name: 'test',
+      };
+      const mockLDS = genMockLicenseDataService();
+      mockLDS.getByUUID.mockResolvedValueOnce({ error: null, data: licenseData });
+      const app = createApp(mockLDS);
+      const res = await request(app)
+        .get(genRoute('/' + testID))
+        .expect('Content-Type', /json/)
+        .expect(200);
+
+      expect(res.body).toEqual({ license: licenseData });
     });
   });
 });

--- a/experimental/license-inventory/src/routes/api/v0/licenses.test.ts
+++ b/experimental/license-inventory/src/routes/api/v0/licenses.test.ts
@@ -40,12 +40,13 @@ describe(basePath, () => {
     const testID = '157c0c6a-5c99-4298-9529-95816da2255a';
     it('invalid id - not uuid', async () => {
       const mockLDS = genMockLicenseDataService();
-      mockLDS.getByUUID.mockResolvedValueOnce({ error: null, data: null });
+      mockLDS.getByUUID.mockRejectedValueOnce(null);
       const app = createApp(mockLDS);
       await request(app)
         .get(genRoute('/' + 'apache-2_0'))
         .expect('Content-Type', /json/)
         .expect(500);
+      expect(mockLDS.getByUUID.mock.lastCall).toBeUndefined();
     });
 
     it('valid id - no data', async () => {

--- a/experimental/license-inventory/src/routes/api/v0/licenses.ts
+++ b/experimental/license-inventory/src/routes/api/v0/licenses.ts
@@ -1,115 +1,118 @@
 import express from 'express';
-import { License } from '@/db/collections';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod';
 import { licenseValidation } from '@/db/schemas/license/license';
-import { trace } from '@opentelemetry/api';
+import { LicenseDataService } from '@/services/data';
 
-const router = express.Router();
+const createRouter = (licenseService: LicenseDataService) => {
+  const router = express.Router();
 
-// CREATE
-const createSchema = z.object({
-  body: licenseValidation.strict().omit({ id: true }),
-});
-router.post('/', async (req, res) => {
-  // TODO: add auth
-  const { error, data } = await createSchema.safeParseAsync(req);
-  if (error) {
-    req.log.error(error);
-    res.status(500).json({ error: 'invalid format' }).end();
-    return;
-  }
-  const { body: submittedLicense } = data;
-  if (submittedLicense.spdxID) {
-    const spdxMatch = await License.findOne({ spdxID: data.body.spdxID }).exec();
-    // already exists
-    if (spdxMatch !== null) {
-      res.status(500).json({ error: 'license with SPDX ID already exists' }).end();
+  // CREATE
+  const createSchema = z.object({
+    body: licenseValidation.strict().omit({ id: true }),
+  });
+  router.post('/', async (req, res) => {
+    // TODO: add auth
+    const { error: parseErr, data: parseData } = await createSchema.safeParseAsync(req);
+    if (parseErr) {
+      req.log.error(parseErr);
+      res.status(500).json({ error: 'invalid format' }).end();
       return;
     }
-  }
-  const _id = uuidv4();
-  await License.create({
-    _id,
-    ...submittedLicense,
+    const { body: submittedLicense } = parseData;
+    const { error, data } = await licenseService.create(submittedLicense);
+    if (error) {
+      req.log.error(parseErr);
+      res.status(500).json({ error: 'failed to create' }).end();
+      return;
+    }
+    res.status(200).json({ created: data }).end();
   });
-  res.status(200).json({ created: _id }).end();
-});
 
-// READ
-const readSchema = z.object({
-  params: licenseValidation.pick({ id: true }).strict(),
-});
-router.get('/:id', async (req, res) => {
-  const { error, data } = await readSchema.safeParseAsync(req);
-  if (error) {
-    req.log.error(error);
-    res.status(500).json({ error: 'invalid format' }).end();
-    return;
-  }
-  const {
-    params: { id },
-  } = data;
-  const license = await (await License.findOne({ _id: id }).exec()).toJSON();
-  res.status(200).json({ license }).end();
-});
+  // READ
+  const readSchema = z.object({
+    params: licenseValidation.pick({ id: true }).strict(),
+  });
+  router.get('/:id', async (req, res) => {
+    const { error: parseErr, data: parseData } = await readSchema.safeParseAsync(req);
+    if (parseErr) {
+      req.log.error(parseErr);
+      res.status(500).json({ error: 'invalid format' }).end();
+      return;
+    }
+    const {
+      params: { id },
+    } = parseData;
 
-// UPDATE
-const updateSchema = z.object({
-  params: licenseValidation.pick({ id: true }).strict(),
-  body: licenseValidation.strict().partial().omit({ id: true }),
-});
-router.patch('/:id', async (req, res) => {
-  const { error, data } = await updateSchema.safeParseAsync(req);
-  if (error) {
-    req.log.error(error);
-    res.status(500).json({ error: 'invalid format' }).end();
-    return;
-  }
-  const {
-    body: updateLicense,
-    params: { id },
-  } = data;
-  await License.findOneAndUpdate({ _id: id }, updateLicense);
-  res.status(204).json({ status: 'ok' }).end();
-});
+    const { error, data: license } = await licenseService.getByUUID(id);
+    if (error) {
+      req.log.error(error);
+      res.status(500).json({ error: 'failed to read' }).end();
+      return;
+    }
+    res.status(200).json({ license }).end();
+  });
 
-// DELETE
-const deleteSchema = z.object({
-  params: licenseValidation.pick({ id: true }).strict(),
-});
-router.delete('/:id', async (req, res) => {
-  const { error, data } = await deleteSchema.safeParseAsync(req);
-  if (error) {
-    req.log.error(error);
-    res.status(500).json({ error: 'invalid format' }).end();
-    return;
-  }
-  const {
-    params: { id },
-  } = data;
-  await License.deleteOne({ _id: id }).exec();
-  res.status(204).json({ status: 'ok' }).end();
-});
+  // UPDATE
+  const updateSchema = z.object({
+    params: licenseValidation.pick({ id: true }).strict(),
+    body: licenseValidation.strict().partial().omit({ id: true }),
+  });
+  router.patch('/:id', async (req, res) => {
+    const { error: parseErr, data: parseData } = await updateSchema.safeParseAsync(req);
+    if (parseErr) {
+      req.log.error(parseErr);
+      res.status(500).json({ error: 'invalid format' }).end();
+      return;
+    }
+    const {
+      body: licenseData,
+      params: { id },
+    } = parseData;
 
-// LIST
-router.get('/', async (req, res) => {
-  const tracer = trace.getTracer('licenses-list');
-  // TODO: pagination
-  const results = await License.find().exec();
-  const jsonifyResultsSpan = tracer.startSpan('jsonify-results');
-  const jsonResults = await Promise.allSettled(results.map(async (doc) => doc.toJSON()));
-  const jsonOutput = jsonResults
-    .filter(<T>(r: PromiseSettledResult<T>): r is PromiseFulfilledResult<T> => {
-      if (r.status === 'rejected') {
-        res.log.warn('failed to convert an object', r.reason);
-        return false;
-      }
-      return true;
-    })
-    .map((r) => r.value);
-  jsonifyResultsSpan.end();
-  res.status(200).json(jsonOutput).end();
-});
+    const { error } = await licenseService.patchByUUID(id, licenseData);
+    if (error) {
+      req.log.error(error);
+      res.status(500).json({ error: 'failed to update' }).end();
+      return;
+    }
+    res.status(204).json({ status: 'ok' }).end();
+  });
 
-export default router;
+  // DELETE
+  const deleteSchema = z.object({
+    params: licenseValidation.pick({ id: true }).strict(),
+  });
+  router.delete('/:id', async (req, res) => {
+    const { error: parseErr, data: parseData } = await deleteSchema.safeParseAsync(req);
+    if (parseErr) {
+      req.log.error(parseErr);
+      res.status(500).json({ error: 'invalid format' }).end();
+      return;
+    }
+    const {
+      params: { id },
+    } = parseData;
+
+    const { error } = await licenseService.deleteByUUID(id);
+    if (error) {
+      req.log.error(error);
+      res.status(500).json({ error: 'failed to delete' }).end();
+      return;
+    }
+    res.status(204).json({ status: 'ok' }).end();
+  });
+
+  // LIST
+  router.get('/', async (req, res) => {
+    const { error, data } = await licenseService.list();
+    if (error) {
+      req.log.error(error);
+      res.status(500).json({ error: 'failed to list' }).end();
+      return;
+    }
+    res.status(200).json(data).end();
+  });
+  return router;
+};
+
+export default createRouter;

--- a/experimental/license-inventory/src/routes/api/v0/licenses.ts
+++ b/experimental/license-inventory/src/routes/api/v0/licenses.ts
@@ -25,7 +25,7 @@ const createRouter = (licenseService: LicenseDataService) => {
       res.status(500).json({ error: 'failed to create' }).end();
       return;
     }
-    res.status(200).json({ created: data }).end();
+    res.status(201).json(data).end();
   });
 
   // READ
@@ -69,13 +69,13 @@ const createRouter = (licenseService: LicenseDataService) => {
       params: { id },
     } = parseData;
 
-    const { error } = await licenseService.patchByUUID(id, licenseData);
+    const { error, data } = await licenseService.patchByUUID(id, licenseData);
     if (error) {
       req.log.error(error);
       res.status(500).json({ error: 'failed to update' }).end();
       return;
     }
-    res.status(204).json({ status: 'ok' }).end();
+    res.status(204).json(data).end();
   });
 
   // DELETE

--- a/experimental/license-inventory/src/server.ts
+++ b/experimental/license-inventory/src/server.ts
@@ -1,23 +1,28 @@
 import { logger } from '@/logger';
 import { connectDB } from './db/connect';
 import env from '@/env';
-import { app } from './app';
+import { createApp } from './app';
+import { MongoLicenseDataService } from './services/data/mongoose';
+import { Database } from './db';
 
 const port = env.PORT;
 
 const run = async () => {
   logger.info('starting server', { port });
-  const dbConnectionRes = connectDB(env.MONGO_URI);
 
-  const { error } = await dbConnectionRes;
+  const { error, data: dbConnection } = await connectDB(env.MONGO_URI);
   if (error !== null) {
     logger.error(error);
     throw new Error('failed to connect to mongo');
   }
+  const db = new Database(dbConnection);
 
   const running = () => {
     logger.info('started server', { port });
   };
+
+  const lds = new MongoLicenseDataService(db);
+  const app = createApp(lds);
   app.listen(port, running);
 };
 run();

--- a/experimental/license-inventory/src/server.ts
+++ b/experimental/license-inventory/src/server.ts
@@ -2,7 +2,7 @@ import { logger } from '@/logger';
 import { connectDB } from './db/connect';
 import env from '@/env';
 import { createApp } from './app';
-import { MongoLicenseDataService } from './services/data/mongoose';
+import { MongooseLicenseDataService } from './services/data/mongoose';
 import { Database } from './db';
 
 const port = env.PORT;
@@ -21,7 +21,7 @@ const run = async () => {
     logger.info('started server', { port });
   };
 
-  const lds = new MongoLicenseDataService(db);
+  const lds = new MongooseLicenseDataService(db);
   const app = createApp(lds);
   app.listen(port, running);
 };

--- a/experimental/license-inventory/src/services/data/index.ts
+++ b/experimental/license-inventory/src/services/data/index.ts
@@ -1,0 +1,19 @@
+import type { AsyncResult } from '@/types';
+import type { License, LicenseCreateUpdate } from './license';
+
+export interface LicenseDataService {
+  create: (licenseData: LicenseCreateUpdate) => AsyncResult<null>;
+
+  getByUUID: (id: string) => AsyncResult<License | null>;
+
+  patchByUUID: (id: string, licenseData: LicenseCreateUpdate) => AsyncResult<null>;
+
+  deleteByUUID: (id: string) => AsyncResult<null>;
+
+  // TODO: consider pagination
+  list: () => AsyncResult<License[]>;
+}
+
+export interface DataService {
+  licenses: LicenseDataService;
+}

--- a/experimental/license-inventory/src/services/data/index.ts
+++ b/experimental/license-inventory/src/services/data/index.ts
@@ -1,12 +1,12 @@
 import type { AsyncResult } from '@/types';
-import type { License, LicenseCreateUpdate } from './license';
+import type { License, LicenseNoID, LicenseNoIDPartial } from './license';
 
 export interface LicenseDataService {
-  create: (licenseData: LicenseCreateUpdate) => AsyncResult<null>;
+  create: (licenseData: LicenseNoID) => AsyncResult<License>;
 
   getByUUID: (id: string) => AsyncResult<License | null>;
 
-  patchByUUID: (id: string, licenseData: LicenseCreateUpdate) => AsyncResult<null>;
+  patchByUUID: (id: string, licenseData: LicenseNoIDPartial) => AsyncResult<License>;
 
   deleteByUUID: (id: string) => AsyncResult<null>;
 

--- a/experimental/license-inventory/src/services/data/license.ts
+++ b/experimental/license-inventory/src/services/data/license.ts
@@ -1,0 +1,45 @@
+import { z } from 'zod';
+
+export const chooseALicense = z.object({
+  permissions: z
+    .object({
+      commercialUse: z.boolean().optional(),
+      modifications: z.boolean().optional(),
+      distribution: z.boolean().optional(),
+      privateUse: z.boolean().optional(),
+      patentUse: z.boolean().optional(),
+    })
+    .optional(),
+  conditions: z
+    .object({
+      includeCopyright: z.boolean().optional(),
+      includeCopyrightSource: z.boolean().optional(),
+      documentChanges: z.boolean().optional(),
+      discloseSource: z.boolean().optional(),
+      networkUseDisclose: z.boolean().optional(),
+      sameLicense: z.boolean().optional(),
+      sameLicenseFile: z.boolean().optional(),
+      sameLicenseLibrary: z.boolean().optional(),
+    })
+    .optional(),
+  limitations: z
+    .object({
+      trademarkUse: z.boolean().optional(),
+      liability: z.boolean().optional(),
+      patentUse: z.boolean().optional(),
+      warranty: z.boolean().optional(),
+    })
+    .optional(),
+});
+export type ChooseALicense = z.infer<typeof chooseALicense>;
+
+export const license = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  spdxID: z.string().optional(),
+  chooseALicenseInfo: chooseALicense.optional(),
+});
+export type License = z.infer<typeof license>;
+
+export const licenseCreateUpdate = license.omit({ id: true });
+export type LicenseCreateUpdate = z.infer<typeof licenseCreateUpdate>;

--- a/experimental/license-inventory/src/services/data/license.ts
+++ b/experimental/license-inventory/src/services/data/license.ts
@@ -41,5 +41,8 @@ export const license = z.object({
 });
 export type License = z.infer<typeof license>;
 
-export const licenseCreateUpdate = license.omit({ id: true });
-export type LicenseCreateUpdate = z.infer<typeof licenseCreateUpdate>;
+export const licenseNoID = license.omit({ id: true });
+export type LicenseNoID = z.infer<typeof licenseNoID>;
+
+export const licenseNoIDPartial = licenseNoID.partial();
+export type LicenseNoIDPartial = z.infer<typeof licenseNoIDPartial>;

--- a/experimental/license-inventory/src/services/data/mongoose/index.ts
+++ b/experimental/license-inventory/src/services/data/mongoose/index.ts
@@ -1,0 +1,84 @@
+import { LicenseDataService } from '../';
+import { Database } from '@/db';
+import { v4 as uuidv4 } from 'uuid';
+import { type LicenseCreateUpdate } from '../license';
+import { trace } from '@opentelemetry/api';
+import { logger } from '@/logger';
+
+export class MongoLicenseDataService implements LicenseDataService {
+  db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+  }
+
+  async create(licenseData: LicenseCreateUpdate) {
+    try {
+      if (licenseData.spdxID) {
+        const spdxMatch = await this.db.License.findOne({ spdxID: licenseData.spdxID })
+          .lean()
+          .exec();
+        // already exists
+        if (spdxMatch !== null) {
+          return { error: new Error('license exists'), data: null };
+        }
+      }
+      const _id = uuidv4();
+      await this.db.License.create({
+        _id,
+        ...licenseData,
+      });
+      return { error: null, data: null };
+    } catch (err: unknown) {
+      return { error: new Error("couldn't register", { cause: err }), data: null };
+    }
+  }
+
+  async getByUUID(id: string) {
+    try {
+      const data = await (await this.db.License.findOne({ _id: id }).exec()).toJSON();
+      return { error: null, data };
+    } catch (err: unknown) {
+      return { error: new Error("couldn't find", { cause: err }), data: null };
+    }
+  }
+
+  async patchByUUID(id: string, details: LicenseCreateUpdate) {
+    try {
+      await this.db.License.findOneAndUpdate({ _id: id }, details);
+      return { error: null, data: null };
+    } catch (err: unknown) {
+      return { error: new Error("couldn't find and update", { cause: err }), data: null };
+    }
+  }
+
+  async deleteByUUID(id: string) {
+    try {
+      await this.db.License.deleteOne({ _id: id }).exec();
+      return { error: null, data: null };
+    } catch (err: unknown) {
+      return { error: new Error("couldn't delete", { cause: err }), data: null };
+    }
+  }
+
+  // TODO: consider pagination
+  async list() {
+    const tracer = trace.getTracer('licenses-list');
+    // TODO: pagination
+    const results = await this.db.License.find().exec();
+    const jsonifyResultsSpan = tracer.startSpan('jsonify-results');
+    const jsonResults = await Promise.allSettled(results.map(async (doc) => doc.toJSON()));
+    const jsonOutput = jsonResults
+      .filter(<T>(r: PromiseSettledResult<T>): r is PromiseFulfilledResult<T> => {
+        if (r.status === 'rejected') {
+          logger.warn('failed to convert an object', r.reason);
+          return false;
+        }
+        return true;
+      })
+      .map((r) => r.value);
+    jsonifyResultsSpan.end();
+
+    return { error: null, data: jsonOutput };
+  }
+}

--- a/experimental/license-inventory/src/test/globalTeardown.ts
+++ b/experimental/license-inventory/src/test/globalTeardown.ts
@@ -1,9 +1,17 @@
 import { MongoMemoryServer } from 'mongodb-memory-server-core';
 import { config } from './utils/config';
 
+declare global {
+  // eslint-disable-next-line no-var
+  var __MONGOINSTANCE: MongoMemoryServer | undefined;
+}
+
 export default async function globalTeardown() {
   if (config.Memory) {
     // Config to decide if an mongodb-memory-server instance should be used
+    if (!(global.__MONGOINSTANCE instanceof MongoMemoryServer)) {
+      throw new Error('expect MongoMemoryServer');
+    }
     const instance: MongoMemoryServer = global.__MONGOINSTANCE;
     await instance.stop();
   }

--- a/experimental/license-inventory/src/test/mock/db.ts
+++ b/experimental/license-inventory/src/test/mock/db.ts
@@ -1,0 +1,12 @@
+import { LicenseDataService } from '@/services/data';
+import { jest } from '@jest/globals';
+
+export const genMockLicenseDataService = (): jest.Mocked<LicenseDataService> => {
+  return {
+    create: jest.fn(),
+    getByUUID: jest.fn(),
+    patchByUUID: jest.fn(),
+    deleteByUUID: jest.fn(),
+    list: jest.fn(),
+  };
+};

--- a/experimental/license-inventory/src/types.ts
+++ b/experimental/license-inventory/src/types.ts
@@ -1,10 +1,14 @@
-export type Result<T> =
-  | {
-      error: Error;
-      data: null;
-    }
-  | {
-      error: null;
-      data: T;
-    };
+export type ResultError = {
+  error: Error;
+  data: null;
+};
+export type ResultSuccess<T> = {
+  error: null;
+  data: T;
+};
+
+export type Result<T> = ResultError | ResultSuccess<T>;
 export type AsyncResult<T> = Promise<Result<T>>;
+
+export const resultIsFailure = <T>(r: Result<T>): r is ResultError => r.error !== null;
+export const resultIsSuccess = <T>(r: Result<T>): r is ResultSuccess<T> => r.error === null;

--- a/experimental/license-inventory/src/types.ts
+++ b/experimental/license-inventory/src/types.ts
@@ -1,14 +1,23 @@
-export type ResultError = {
-  error: Error;
-  data: null;
-};
-export type ResultSuccess<T> = {
-  error: null;
-  data: T;
-};
-
-export type Result<T> = ResultError | ResultSuccess<T>;
+export type Result<T> =
+  | {
+      error: Error;
+      data: null;
+    }
+  | {
+      error: null;
+      data: T;
+    };
 export type AsyncResult<T> = Promise<Result<T>>;
 
-export const resultIsFailure = <T>(r: Result<T>): r is ResultError => r.error !== null;
-export const resultIsSuccess = <T>(r: Result<T>): r is ResultSuccess<T> => r.error === null;
+export const resultIsFailure = <T>(
+  r: Result<T>,
+): r is {
+  error: Error;
+  data: null;
+} => r.error !== null;
+export const resultIsSuccess = <T>(
+  r: Result<T>,
+): r is {
+  error: null;
+  data: T;
+} => r.error === null;

--- a/experimental/license-inventory/tsconfig.json
+++ b/experimental/license-inventory/tsconfig.json
@@ -2,7 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "target": "es2017",
-    "lib": ["es2017", "esnext.asynciterable"],
+    "lib": ["ES2022", "esnext.asynciterable"],
     "typeRoots": ["node_modules/@types"],
     "allowSyntheticDefaultImports": true,
     "experimentalDecorators": true,

--- a/experimental/license-inventory/tsconfig.json
+++ b/experimental/license-inventory/tsconfig.json
@@ -2,6 +2,7 @@
   "compileOnSave": false,
   "compilerOptions": {
     "target": "es2017",
+    "strict": true,
     "lib": ["ES2022", "esnext.asynciterable"],
     "typeRoots": ["node_modules/@types"],
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
Defined a database layer
Added an implementation using mongoose
Refactored the express routes to take an implementation
Added a mockable implementation
Refactored the tests to use the mockable implementation
Added tests for the get by uuid route

---

I'm not huge on OOP so the classes are more similar to go services
This method allows for easier mocking of the DB interactions with correct typechecking.
We also get to ensure we're using the same DB connection everywhere rather than trusting global variables.