### PR TITLE
chore: bump experimental license inventory to 0.0.2 with #854

### DIFF
--- a/experimental/license-inventory/package-lock.json
+++ b/experimental/license-inventory/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/git-proxy-license-inventory",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/git-proxy-license-inventory",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "body-parser": "^1.20.3",

--- a/experimental/license-inventory/package.json
+++ b/experimental/license-inventory/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy-license-inventory",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "git-proxy contributors",
   "license": "Apache-2.0",
   "files": [


### PR DESCRIPTION
Bumps license inventory to `v0.0.2` with latest changes from #854 👍 

(cc) @06kellyjac 