### PR TITLE
fix: missing query parameter in file db

### DIFF
--- a/packages/git-proxy-cli/test/testCli.test.js
+++ b/packages/git-proxy-cli/test/testCli.test.js
@@ -645,10 +645,12 @@ describe('test git-proxy-cli', function () {
 
   describe('test git-proxy-cli :: git push administration', function () {
     const pushId = `0000000000000000000000000000000000000000__${Date.now()}`;
+    const gitAccount = 'testGitAccount1';
 
     before(async function () {
       await helper.addRepoToDb(TEST_REPO_CONFIG);
-      await helper.addGitPushToDb(pushId, TEST_REPO);
+      await helper.addUserToDb('testuser1', 'testpassword', 'test@email.com', gitAccount);
+      await helper.addGitPushToDb(pushId, TEST_REPO, gitAccount);
     });
 
     it('attempt to ls should list existing push', async function () {

--- a/packages/git-proxy-cli/test/testCliUtils.js
+++ b/packages/git-proxy-cli/test/testCliUtils.js
@@ -170,7 +170,7 @@ async function addRepoToDb(newRepo, debug = false) {
  * @param {string} repo The repository of the git push.
  * @param {boolean} debug Flag to enable logging for debugging.
  */
-async function addGitPushToDb(id, repo, debug = false) {
+async function addGitPushToDb(id, repo, user = null, debug = false) {
   const action = new actions.Action(
     id,
     'push', // type
@@ -178,6 +178,7 @@ async function addGitPushToDb(id, repo, debug = false) {
     Date.now(), // timestamp
     repo,
   );
+  action.user = user;
   const step = new steps.Step(
     'authBlock', // stepName
     false, // error

--- a/src/db/file/users.js
+++ b/src/db/file/users.js
@@ -78,7 +78,7 @@ exports.updateUser = function (user) {
 exports.getUsers = function (query) {
   if (!query) query = {};
   return new Promise((resolve, reject) => {
-    db.find({}, (err, docs) => {
+    db.find(query, (err, docs) => {
       if (err) {
         reject(err);
       } else {


### PR DESCRIPTION
The `getUsers` function in the file db did not correctly use the provided query parameter. 
Adjusted `addGitPushToDb` function by allowing the user parameter to be explicitly passed.