### PR TITLE
fix: clean up .remote folder after tests and extend timeout

### DIFF
--- a/test/testClearBareClone.test.js
+++ b/test/testClearBareClone.test.js
@@ -25,7 +25,7 @@ describe('clear bare and local clones', async () => {
     );
 
     expect(fs.existsSync(`./.remote/${timestamp}`)).to.be.true;
-  }).timeout(10000);
+  }).timeout(20000);
 
   it('clear bare clone function purges .remote folder and specific clone folder', async () => {
     const action = new Action('123', 'type', 'get', timestamp, 'finos/git-proxy');
@@ -33,4 +33,10 @@ describe('clear bare and local clones', async () => {
     expect(fs.existsSync(`./.remote`)).to.throw;
     expect(fs.existsSync(`./.remote/${timestamp}`)).to.throw;
   });
+
+  afterEach(() => {
+    if (fs.existsSync(`./.remote`)) {
+      fs.rmdirSync(`./.remote`, { recursive: true });
+    }
+  })
 });


### PR DESCRIPTION
Hi, this PR fixes the following flaky tests:

![image](https://github.com/user-attachments/assets/c602d389-c460-47b0-b10b-0a0ee72afe72)