### PR TITLE
docs: add note on npx proxy configuration

### DIFF
--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -28,3 +28,9 @@ npx -- @finos/git-proxy
 ```bash
 npx -- @finos/git-proxy-cli
 ```
+
+If you use a proxy server to access npm then please note that you also need to configure your proxy for npx before running the above commands:
+
+```bash
+npx config set https-proxy <company-proxy-endpoint>
+```

--- a/website/docs/usage.mdx
+++ b/website/docs/usage.mdx
@@ -29,7 +29,7 @@ npx -- @finos/git-proxy
 npx -- @finos/git-proxy-cli
 ```
 
-If you use a proxy server to access npm then please note that you also need to configure your proxy for npx before running the above commands:
+If you use a proxy server to access `npm` then please note that you also need to configure your proxy for `npx` before running the above commands:
 
 ```bash
 npx config set https-proxy <company-proxy-endpoint>


### PR DESCRIPTION
resolves #724 

Adds a small note to documentation on configuring a web proxy for `npx`