### PR TITLE
fix: repository listing default query

### DIFF
--- a/src/db/file/repo.ts
+++ b/src/db/file/repo.ts
@@ -7,7 +7,7 @@ if (!fs.existsSync('./.data/db')) fs.mkdirSync('./.data/db');
 
 const db = new Datastore({ filename: './.data/db/repos.db', autoload: true });
 
-export const getRepos = async (query: any = {}) => {
+export  const getRepos = async (query: any = {}) => {
   return new Promise<Repo[]>((resolve, reject) => {
     db.find({}, (err: Error, docs: Repo[]) => {
       if (err) {

--- a/src/service/routes/repo.js
+++ b/src/service/routes/repo.js
@@ -5,9 +5,7 @@ const { getProxyURL } = require('../urls');
 
 router.get('/', async (req, res) => {
   const proxyURL = getProxyURL(req);
-  const query = {
-    type: 'push',
-  };
+  const query = {};
 
   for (const k in req.query) {
     if (!k) continue;

--- a/test/addRepoTest.test.js
+++ b/test/addRepoTest.test.js
@@ -28,7 +28,7 @@ describe('add new repo', async () => {
     await db.deleteUser('u1');
     await db.deleteUser('u2');
     await db.createUser('u1', 'abc', 'test@test.com', 'test', true);
-    await db.createUser('u2', 'abc', 'test@test.com', 'test', true);
+    await db.createUser('u2', 'abc', 'test2@test.com', 'test', true);
   });
 
   it('login', async function () {
@@ -187,5 +187,8 @@ describe('add new repo', async () => {
 
   after(async function () {
     await service.httpServer.close();
+    await db.deleteRepo('test-repo');
+    await db.deleteUser('u1');
+    await db.deleteUser('u2');
   });
 });

--- a/test/testUserCreation.test.js
+++ b/test/testUserCreation.test.js
@@ -55,8 +55,7 @@ describe('user creation', async () => {
   });
 
   it('login as new user', async function () {
-    // we don't know the users tempoary password - so force update a
-    // pasword
+    // we don't know the users temporary password - so force update a password
     const user = await db.findUser('login-test-user');
 
     await bcrypt.hash('test1234', 10, async function (err, hash) {


### PR DESCRIPTION
resolves #947

The repository page passes an incorrect query by default. This is currently ok as the database clients ignore it, but to fix them we first need to fix the query in this page.