### PR TITLE
fix: push parsing drops commit messages unless they end in a newline

### DIFF
--- a/packages/git-proxy-cli/test/testCli.test.js
+++ b/packages/git-proxy-cli/test/testCli.test.js
@@ -19,8 +19,8 @@ const GHOST_PUSH_ID =
 const TEST_REPO_CONFIG = {
   project: 'finos',
   name: 'git-proxy-test',
-  url: 'https://github.com/finos/git-proxy-test.git'
-}
+  url: 'https://github.com/finos/git-proxy-test.git',
+};
 const TEST_REPO = 'finos/git-proxy-test.git';
 
 describe('test git-proxy-cli', function () {
@@ -36,12 +36,7 @@ describe('test git-proxy-cli', function () {
         'Options:',
         'You need at least one command before moving on',
       ];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it(`print help if invalid command or option is given`, async function () {
@@ -53,12 +48,7 @@ describe('test git-proxy-cli', function () {
         'Options:',
         'Unknown arguments: invalid, invalid',
       ];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it(`print help if "--help" option is given`, async function () {
@@ -66,12 +56,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 0;
       const expectedMessages = ['Commands:', 'Options:'];
       const expectedErrorMessages = null;
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
   });
 
@@ -83,12 +68,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 0;
       const expectedMessages = ['0.1.0'];
       const expectedErrorMessages = null;
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
   });
 
@@ -100,12 +80,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 0;
       const expectedMessages = ['GitProxy URL:'];
       const expectedErrorMessages = null;
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
   });
 
@@ -117,12 +92,11 @@ describe('test git-proxy-cli', function () {
     const testEmail = 'jane.doe@email.com';
 
     before(async function () {
-      await helper.addUserToDb(
-        testUser,
-        testPassword,
-        testEmail,
-        'testGitAccount',
-      );
+      await helper.addUserToDb(testUser, testPassword, testEmail, 'testGitAccount');
+    });
+
+    after(async function () {
+      await helper.removeUserFromDb(testUser);
     });
 
     it('login shoud fail when server is down', async function () {
@@ -132,12 +106,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 2;
       const expectedMessages = null;
       const expectedErrorMessages = [`Error: Login '${username}':`];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('login shoud fail with invalid credentials', async function () {
@@ -149,12 +118,7 @@ describe('test git-proxy-cli', function () {
       const expectedErrorMessages = [`Error: Login '${username}': '401'`];
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -165,18 +129,11 @@ describe('test git-proxy-cli', function () {
       const password = 'admin';
       const cli = `npx -- @finos/git-proxy-cli login --username ${username} --password ${password}`;
       const expectedExitCode = 0;
-      const expectedMessages = [
-        `Login "${username}" <admin@place.com> (admin): OK`,
-      ];
+      const expectedMessages = [`Login "${username}" <admin@place.com> (admin): OK`];
       const expectedErrorMessages = null;
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -189,12 +146,7 @@ describe('test git-proxy-cli', function () {
       const expectedErrorMessages = null;
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -211,20 +163,13 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 0;
       const expectedMessages = [`Logout: OK`];
       const expectedErrorMessages = null;
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('logout should succeed when server is down (but logged in before)', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -233,12 +178,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 0;
       const expectedMessages = [`Logout: OK`];
       const expectedErrorMessages = null;
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('logout should succeed when not authenticated (server is up)', async function () {
@@ -250,12 +190,7 @@ describe('test git-proxy-cli', function () {
         const expectedMessages = [`Logout: OK`];
         const expectedErrorMessages = null;
         await helper.startServer(service);
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -264,20 +199,13 @@ describe('test git-proxy-cli', function () {
     it('logout shoud be successful when authenticated (server is up)', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli logout`;
         const expectedExitCode = 0;
         const expectedMessages = [`Logout: OK`];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -289,18 +217,21 @@ describe('test git-proxy-cli', function () {
   describe('test git-proxy-cli :: authorise', function () {
     const pushId = `auth000000000000000000000000000000000000__${Date.now()}`;
 
-    before(async function() {
+    before(async function () {
       await helper.addRepoToDb(TEST_REPO_CONFIG);
       await helper.addGitPushToDb(pushId, TEST_REPO);
-    })
+    });
+
+    after(async function () {
+      await helper.removeGitPushFromDb(pushId);
+      await helper.removeRepoFromDb(TEST_REPO_CONFIG.name);
+    });
 
     it('attempt to authorise should fail when server is down', async function () {
       try {
         // start server -> login -> stop server
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -310,12 +241,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 2;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: Authorise:'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to authorise should fail when not authenticated', async function () {
@@ -325,15 +251,8 @@ describe('test git-proxy-cli', function () {
       const cli = `npx -- @finos/git-proxy-cli authorise --id ${id}`;
       const expectedExitCode = 1;
       const expectedMessages = null;
-      const expectedErrorMessages = [
-        'Error: Authorise: Authentication required',
-      ];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      const expectedErrorMessages = ['Error: Authorise: Authentication required'];
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to authorise should fail when not authenticated (server restarted)', async function () {
@@ -344,15 +263,8 @@ describe('test git-proxy-cli', function () {
         const cli = `npx -- @finos/git-proxy-cli authorise --id ${id}`;
         const expectedExitCode = 3;
         const expectedMessages = null;
-        const expectedErrorMessages = [
-          'Error: Authorise: Authentication required',
-        ];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        const expectedErrorMessages = ['Error: Authorise: Authentication required'];
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -361,23 +273,14 @@ describe('test git-proxy-cli', function () {
     it('attempt to authorise should fail when git push ID not found', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const id = GHOST_PUSH_ID;
         const cli = `npx -- @finos/git-proxy-cli authorise --id ${id}`;
         const expectedExitCode = 4;
         const expectedMessages = null;
-        const expectedErrorMessages = [
-          `Error: Authorise: ID: '${id}': Not Found`,
-        ];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        const expectedErrorMessages = [`Error: Authorise: ID: '${id}': Not Found`];
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -389,18 +292,21 @@ describe('test git-proxy-cli', function () {
   describe('test git-proxy-cli :: cancel', function () {
     const pushId = `cancel0000000000000000000000000000000000__${Date.now()}`;
 
-    before(async function() {
+    before(async function () {
       await helper.addRepoToDb(TEST_REPO_CONFIG);
       await helper.addGitPushToDb(pushId, TEST_REPO);
-    })
-    
+    });
+
+    after(async function () {
+      await helper.removeGitPushFromDb(pushId);
+      await helper.removeRepoFromDb(TEST_REPO_CONFIG.name);
+    });
+
     it('attempt to cancel should fail when server is down', async function () {
       try {
         // start server -> login -> stop server
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -410,12 +316,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 2;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: Cancel:'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to cancel should fail when not authenticated', async function () {
@@ -426,12 +327,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 1;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: Cancel: Authentication required'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to cancel should fail when not authenticated (server restarted)', async function () {
@@ -442,15 +338,8 @@ describe('test git-proxy-cli', function () {
         const cli = `npx -- @finos/git-proxy-cli cancel --id ${id}`;
         const expectedExitCode = 3;
         const expectedMessages = null;
-        const expectedErrorMessages = [
-          'Error: Cancel: Authentication required',
-        ];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        const expectedErrorMessages = ['Error: Cancel: Authentication required'];
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
         // });
       } finally {
         await helper.closeServer(service.httpServer);
@@ -460,21 +349,14 @@ describe('test git-proxy-cli', function () {
     it('attempt to cancel should fail when git push ID not found', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const id = GHOST_PUSH_ID;
         const cli = `npx -- @finos/git-proxy-cli cancel --id ${id}`;
         const expectedExitCode = 4;
         const expectedMessages = null;
         const expectedErrorMessages = [`Error: Cancel: ID: '${id}': Not Found`];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -488,9 +370,7 @@ describe('test git-proxy-cli', function () {
       try {
         // start server -> login -> stop server
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -499,12 +379,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 2;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: List:'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to ls should fail when not authenticated', async function () {
@@ -514,31 +389,19 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 1;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: List: Authentication required'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to ls should fail when invalid option given', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --invalid`;
         const expectedExitCode = 1;
         const expectedMessages = null;
         const expectedErrorMessages = ['Options:', 'Unknown argument: invalid'];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -550,18 +413,21 @@ describe('test git-proxy-cli', function () {
   describe('test git-proxy-cli :: reject', function () {
     const pushId = `reject0000000000000000000000000000000000__${Date.now()}`;
 
-    before(async function() {
+    before(async function () {
       await helper.addRepoToDb(TEST_REPO_CONFIG);
       await helper.addGitPushToDb(pushId, TEST_REPO);
-    })
-    
+    });
+
+    after(async function () {
+      await helper.removeGitPushFromDb(pushId);
+      await helper.removeRepoFromDb(TEST_REPO_CONFIG.name);
+    });
+
     it('attempt to reject should fail when server is down', async function () {
       try {
         // start server -> login -> stop server
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -571,12 +437,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 2;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: Reject:'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to reject should fail when not authenticated', async function () {
@@ -587,12 +448,7 @@ describe('test git-proxy-cli', function () {
       const expectedExitCode = 1;
       const expectedMessages = null;
       const expectedErrorMessages = ['Error: Reject: Authentication required'];
-      await helper.runCli(
-        cli,
-        expectedExitCode,
-        expectedMessages,
-        expectedErrorMessages,
-      );
+      await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
     });
 
     it('attempt to reject should fail when not authenticated (server restarted)', async function () {
@@ -603,15 +459,8 @@ describe('test git-proxy-cli', function () {
         const cli = `npx -- @finos/git-proxy-cli reject --id ${id}`;
         const expectedExitCode = 3;
         const expectedMessages = null;
-        const expectedErrorMessages = [
-          'Error: Reject: Authentication required',
-        ];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        const expectedErrorMessages = ['Error: Reject: Authentication required'];
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -620,21 +469,14 @@ describe('test git-proxy-cli', function () {
     it('attempt to reject should fail when git push ID not found', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const id = GHOST_PUSH_ID;
         const cli = `npx -- @finos/git-proxy-cli reject --id ${id}`;
         const expectedExitCode = 4;
         const expectedMessages = null;
         const expectedErrorMessages = [`Error: Reject: ID: '${id}': Not Found`];
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -653,12 +495,16 @@ describe('test git-proxy-cli', function () {
       await helper.addGitPushToDb(pushId, TEST_REPO, gitAccount);
     });
 
+    after(async function () {
+      await helper.removeUserFromDb('testuser1');
+      await helper.removeGitPushFromDb(pushId);
+      await helper.removeRepoFromDb(TEST_REPO_CONFIG.name);
+    });
+
     it('attempt to ls should list existing push', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --authorised false --blocked true --canceled false --rejected false`;
         const expectedExitCode = 0;
@@ -672,12 +518,7 @@ describe('test git-proxy-cli', function () {
           'rejected: false',
         ];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -686,20 +527,13 @@ describe('test git-proxy-cli', function () {
     it('attempt to ls should not list existing push when filtered for authorised', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --authorised true`;
         const expectedExitCode = 0;
         const expectedMessages = ['[]'];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -708,20 +542,13 @@ describe('test git-proxy-cli', function () {
     it('attempt to ls should not list existing push when filtered for canceled', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --canceled true`;
         const expectedExitCode = 0;
         const expectedMessages = ['[]'];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -730,20 +557,13 @@ describe('test git-proxy-cli', function () {
     it('attempt to ls should not list existing push when filtered for rejected', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --rejected true`;
         const expectedExitCode = 0;
         const expectedMessages = ['[]'];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -752,20 +572,13 @@ describe('test git-proxy-cli', function () {
     it('attempt to ls should not list existing push when filtered for non-blocked', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         const cli = `npx -- @finos/git-proxy-cli ls --blocked false`;
         const expectedExitCode = 0;
         const expectedMessages = ['[]'];
         const expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -774,42 +587,25 @@ describe('test git-proxy-cli', function () {
     it('authorise push and test if appears on authorised list', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         let cli = `npx -- @finos/git-proxy-cli ls --authorised true --canceled false --rejected false`;
         let expectedExitCode = 0;
         let expectedMessages = ['[]'];
         let expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli authorise --id ${pushId}`;
         expectedExitCode = 0;
         expectedMessages = [`Authorise: ID: '${pushId}': OK`];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli ls --authorised true --canceled false --rejected false`;
         expectedExitCode = 0;
         expectedMessages = [pushId, TEST_REPO];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -818,42 +614,25 @@ describe('test git-proxy-cli', function () {
     it('reject push and test if appears on rejected list', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         let cli = `npx -- @finos/git-proxy-cli ls --authorised false --canceled false --rejected true`;
         let expectedExitCode = 0;
         let expectedMessages = ['[]'];
         let expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli reject --id ${pushId}`;
         expectedExitCode = 0;
         expectedMessages = [`Reject: ID: '${pushId}': OK`];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli ls --authorised false --canceled false --rejected true`;
         expectedExitCode = 0;
         expectedMessages = [pushId, TEST_REPO];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
       }
@@ -862,42 +641,25 @@ describe('test git-proxy-cli', function () {
     it('cancel push and test if appears on canceled list', async function () {
       try {
         await helper.startServer(service);
-        await helper.runCli(
-          `npx -- @finos/git-proxy-cli login --username admin --password admin`,
-        );
+        await helper.runCli(`npx -- @finos/git-proxy-cli login --username admin --password admin`);
 
         let cli = `npx -- @finos/git-proxy-cli ls --authorised false --canceled true --rejected false`;
         let expectedExitCode = 0;
         let expectedMessages = ['[]'];
         let expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli cancel --id ${pushId}`;
         expectedExitCode = 0;
         expectedMessages = [`Cancel: ID: '${pushId}': OK`];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
         cli = `npx -- @finos/git-proxy-cli ls --authorised false --canceled true --rejected false`;
         expectedExitCode = 0;
         expectedMessages = [pushId, TEST_REPO];
         expectedErrorMessages = null;
-        await helper.runCli(
-          cli,
-          expectedExitCode,
-          expectedMessages,
-          expectedErrorMessages,
-        );
+        await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
       } finally {
         await helper.closeServer(service.httpServer);
         await helper.removeCookiesFile();

--- a/packages/git-proxy-cli/test/testCliUtils.js
+++ b/packages/git-proxy-cli/test/testCliUtils.js
@@ -165,6 +165,14 @@ async function addRepoToDb(newRepo, debug = false) {
 }
 
 /**
+ * Removes a repo from the DB.
+ * @param {string} repoName  The name of the repo to remove.
+ */
+async function removeRepoFromDb(repoName) {
+  await db.deleteRepo(repoName);
+}
+
+/**
  * Add a new git push record to the database.
  * @param {string} id The ID of the git push.
  * @param {string} repo The repository of the git push.
@@ -206,6 +214,14 @@ async function addGitPushToDb(id, repo, user = null, debug = false) {
 }
 
 /**
+ * Removes a push from the DB
+ * @param {string} id
+ */
+async function removeGitPushFromDb(id) {
+  await db.deletePush(id);
+}
+
+/**
  * Add new user record to the database.
  * @param {string} username The user name.
  * @param {string} password The user password.
@@ -221,13 +237,24 @@ async function addUserToDb(username, password, email, gitAccount, admin = false,
   }
 }
 
+/**
+ * Remove a user record from the database if present.
+ * @param {string} username The user name.
+ */
+async function removeUserFromDb(username) {
+  await db.deleteUser(username);
+}
+
 module.exports = {
   runCli: runCli,
   startServer: startServer,
   closeServer: closeServer,
   addRepoToDb: addRepoToDb,
+  removeRepoFromDb: removeRepoFromDb,
   addGitPushToDb: addGitPushToDb,
+  removeGitPushFromDb: removeGitPushFromDb,
   addUserToDb: addUserToDb,
+  removeUserFromDb: removeUserFromDb,
   createCookiesFileWithExpiredCookie: createCookiesFileWithExpiredCookie,
   removeCookiesFile: removeCookiesFile,
 };

--- a/src/db/file/index.ts
+++ b/src/db/file/index.ts
@@ -6,6 +6,7 @@ export const {
   getPushes,
   writeAudit,
   getPush,
+  deletePush,
   authorise,
   cancel,
   reject,
@@ -26,11 +27,4 @@ export const {
   canUserApproveRejectPushRepo,
 } = repo;
 
-export const {
-  findUser,
-  findUserByOIDC,
-  getUsers,
-  createUser,
-  deleteUser,
-  updateUser,
-} = users;
+export const { findUser, findUserByOIDC, getUsers, createUser, deleteUser, updateUser } = users;

--- a/src/db/file/pushes.ts
+++ b/src/db/file/pushes.ts
@@ -4,7 +4,7 @@ import Datastore from '@seald-io/nedb';
 import { Action } from '../../proxy/actions/Action';
 import { toClass } from '../helper';
 import * as repo from './repo';
-import { PushQuery } from '../types'
+import { PushQuery } from '../types';
 
 if (!fs.existsSync('./.data')) fs.mkdirSync('./.data');
 if (!fs.existsSync('./.data/db')) fs.mkdirSync('./.data/db');
@@ -46,6 +46,18 @@ export const getPush = async (id: string) => {
         } else {
           resolve(toClass(doc, Action.prototype));
         }
+      }
+    });
+  });
+};
+
+export const deletePush = async (id: string) => {
+  return new Promise<void>((resolve, reject) => {
+    db.remove({ id }, (err) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve();
       }
     });
   });

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -63,6 +63,7 @@ export const {
   getPushes,
   writeAudit,
   getPush,
+  deletePush,
   findUser,
   findUserByOIDC,
   getUsers,

--- a/src/db/mongo/index.ts
+++ b/src/db/mongo/index.ts
@@ -1,16 +1,15 @@
 import * as helper from './helper';
 import * as pushes from './pushes';
-import * as repo  from './repo';
+import * as repo from './repo';
 import * as users from './users';
 
-export const {
-  getSessionStore,
-} = helper;
+export const { getSessionStore } = helper;
 
 export const {
   getPushes,
   writeAudit,
   getPush,
+  deletePush,
   authorise,
   cancel,
   reject,
@@ -31,10 +30,4 @@ export const {
   canUserApproveRejectPushRepo,
 } = repo;
 
-export const {
-  findUser,
-  getUsers,
-  createUser,
-  deleteUser,
-  updateUser,
-} = users;
+export const { findUser, getUsers, createUser, deleteUser, updateUser } = users;

--- a/src/db/mongo/pushes.ts
+++ b/src/db/mongo/pushes.ts
@@ -13,9 +13,7 @@ const defaultPushQuery: PushQuery = {
   authorised: false,
 };
 
-export const getPushes = async (
-  query: PushQuery = defaultPushQuery
-): Promise<Push[]> => {
+export const getPushes = async (query: PushQuery = defaultPushQuery): Promise<Push[]> => {
   return findDocuments<Push>(collectionName, query, {
     projection: {
       _id: 0,
@@ -44,7 +42,12 @@ export const getPushes = async (
 
 export const getPush = async (id: string): Promise<Action | null> => {
   const doc = await findOneDocument<any>(collectionName, { id });
-  return doc ? toClass(doc, Action.prototype) as Action : null;
+  return doc ? (toClass(doc, Action.prototype) as Action) : null;
+};
+
+export const deletePush = async function (id: string) {
+  const collection = await connect(collectionName);
+  return collection.deleteOne({ id });
 };
 
 export const writeAudit = async (action: Action): Promise<Action> => {

--- a/src/proxy/processors/push-action/parsePush.ts
+++ b/src/proxy/processors/push-action/parsePush.ts
@@ -99,9 +99,9 @@ const getCommitData = (contents: CommitContent[]) => {
       const indexOfMessages = formattedContent.indexOf('');
       console.log({ indexOfMessages });
 
-      const message = formattedContent
-        .slice(indexOfMessages + 1, formattedContent.length - 1)
-        .join(' ');
+      const message = formattedContent 
+        .slice(indexOfMessages + 1) 
+        .join(' ').trim(); 
       console.log({ message });
 
       const commitTimestamp = committer?.split(' ').reverse()[1];

--- a/test/addRepoTest.test.js
+++ b/test/addRepoTest.test.js
@@ -28,7 +28,7 @@ describe('add new repo', async () => {
     await db.deleteUser('u1');
     await db.deleteUser('u2');
     await db.createUser('u1', 'abc', 'test@test.com', 'test', true);
-    await db.createUser('u2', 'abc', 'test@test.com', 'test', true);
+    await db.createUser('u2', 'abc', 'test2@test.com', 'test', true);
   });
 
   it('login', async function () {
@@ -187,5 +187,8 @@ describe('add new repo', async () => {
 
   after(async function () {
     await service.httpServer.close();
+    await db.deleteRepo('test-repo');
+    await db.deleteUser('u1');
+    await db.deleteUser('u2');
   });
 });

--- a/test/testUserCreation.test.js
+++ b/test/testUserCreation.test.js
@@ -55,8 +55,7 @@ describe('user creation', async () => {
   });
 
   it('login as new user', async function () {
-    // we don't know the users tempoary password - so force update a
-    // pasword
+    // we don't know the users temporary password - so force update a password
     const user = await db.findUser('login-test-user');
 
     await bcrypt.hash('test1234', 10, async function (err, hash) {


### PR DESCRIPTION
resolves #971

Adjusts push parsing to not require a newline at the end commit messages in order to capture them.

Also adjusts CLI tests to clean up the rows they create, so that they can be run multiple times without the DB files needing to be reset.