### PR TITLE
Fix: updated README and documentation site with info on community meeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,6 @@ Drop a note, ask a question or just say hello in our [community Slack channel](h
 
 If you can't access Slack, you can also [subscribe to our mailing list](mailto:git-proxy+subscribe@lists.finos.org).
 
-Join our [fortnightly Zoom meeting](https://zoom.us/j/97235277537?pwd=aDJsaE8zcDJpYW1vZHJmSTJ0RXNZUT09) on Monday, 11AM EST (odd week numbers). Send an e-mail to [help@finos.org](mailto:help@finos.org) to get a calendar invitation.
+Join our [fortnightly Zoom meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/95849833904?password=99413314-d03a-4b1c-b682-1ede2c399595) on Monday, 11AM EST (odd week numbers). [Click here](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MTRvbzM0NG01dWNvNGc4OGJjNWphM2ZtaTZfMjAyNTA2MDJUMTUwMDAwWiBzYW0uaG9sbWVzQGNvbnRyb2wtcGxhbmUuaW8&tmsrc=sam.holmes%40control-plane.io&scp=ALL) for the recurring Google Calendar meeting invite. Alternatively, send an e-mail to [help@finos.org](https://zoom-lfx.platform.linuxfoundation.org/meeting/95849833904?password=99413314-d03a-4b1c-b682-1ede2c399595#:~:text=Need-,an,-invite%3F) to get a calendar invitation. 
 
 Otherwise, if you have a deeper query or require more support, please [raise an issue](https://github.com/finos/git-proxy/issues).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/git-proxy",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/git-proxy",
-      "version": "1.13.0",
+      "version": "1.14.0",
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/git-proxy-cli"
@@ -25,6 +25,7 @@
         "connect-mongo": "^5.1.0",
         "cors": "^2.8.5",
         "diff2html": "^3.4.33",
+        "env-paths": "^2.2.1",
         "express": "^4.18.2",
         "express-http-proxy": "^2.0.0",
         "express-rate-limit": "^7.1.5",
@@ -6168,7 +6169,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
       "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Deploy custom push protections and policies on top of Git.",
   "scripts": {
     "cli": "node ./packages/git-proxy-cli/index.js",

--- a/website/docs/development/contributing.mdx
+++ b/website/docs/development/contributing.mdx
@@ -41,3 +41,10 @@ When updating the configuration schema, you must also re-generate the reference 
 
 ## About FINOS contributions
 <!-- Notes around signing the CLA. See existing CONTRIBUTING.md -->
+
+## Community Meetings
+Join our [fortnightly Zoom meeting](https://zoom-lfx.platform.linuxfoundation.org/meeting/95849833904?password=99413314-d03a-4b1c-b682-1ede2c399595) on Monday, 11AM EST (odd week numbers). 
+[Click here](https://calendar.google.com/calendar/event?action=TEMPLATE&tmeid=MTRvbzM0NG01dWNvNGc4OGJjNWphM2ZtaTZfMjAyNTA2MDJUMTUwMDAwWiBzYW0uaG9sbWVzQGNvbnRyb2wtcGxhbmUuaW8&tmsrc=sam.holmes%40control-plane.io&scp=ALL) for the recurring Google Calendar meeting invite. 
+Alternatively, send an e-mail to [help@finos.org](https://zoom-lfx.platform.linuxfoundation.org/meeting/95849833904?password=99413314-d03a-4b1c-b682-1ede2c399595#:~:text=Need-,an,-invite%3F) to get a calendar invitation. 
+
+Previous recordings available at: https://openprofile.dev


### PR DESCRIPTION
Fixes #1020 

- [-] Update README.md to use [LFX meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/95849833904?password=99413314-d03a-4b1c-b682-1ede2c399595) for fortnightly calls 
- [-] Verify date, time and time zone are correct in README.md
- [-] Create a calendar auto-populate link with recurring meeting + LFX link
- [-] Add hero to docs site to advertise fortnightly meetings and share previous recordings