### PR TITLE
fix: correct typing for ConfigLoader env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,12 @@ jobs:
     - name: Install dependencies
       run: npm i
 
+    # for now only check the types of the server
+    # tsconfig isn't quite set up right to respect what vite accepts
+    # for the frontend code
+    - name: Check Types (Server)
+      run: npm run check-types:server
+
     - name: Test
       id: test
       run: |

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "build-lib": "./scripts/build-for-publish.sh",
     "restore-lib": "./scripts/undo-build.sh",
     "check-types": "tsc",
+    "check-types:server": "tsc --project tsconfig.publish.json --noEmit",
     "test": "NODE_ENV=test ts-mocha './test/**/*.test.js' --exit",
     "test-coverage": "nyc npm run test",
     "test-coverage-ci": "nyc --reporter=lcovonly --reporter=text npm run test",

--- a/src/config/ConfigLoader.ts
+++ b/src/config/ConfigLoader.ts
@@ -317,7 +317,8 @@ export class ConfigLoader extends EventEmitter {
         cwd: process.cwd(),
         env: {
           // dont wait for credentials; the command should be sufficiently authed
-          GIT_TERMINAL_PROMPT: 0,
+          // https://git-scm.com/docs/git#Documentation/git.txt-codeGITTERMINALPROMPTcode
+          GIT_TERMINAL_PROMPT: 'false',
           ...process.env,
           ...(source.auth?.type === 'ssh'
             ? {


### PR DESCRIPTION
**fix: correct typing for ConfigLoader env**

Was providing a number which can be coerced to a string but TS is a bit more strict asking for string values for env.

Also swapped 0 to false to be more clear and added a docs link.

**chore: add tsc for just server and add to CI**

Add type checking for the server to CI.
Type Checking for the whole project would be good but the frontend has some typechecking rules which work fine for the build but tsc doesn't currently respect. Will fix in the future.
