### PR TITLE
feat: mongo connection string & cookie secret from env vars

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -3,6 +3,8 @@ export type ServerConfig = {
   GIT_PROXY_HTTPS_SERVER_PORT: string | number;
   GIT_PROXY_UI_HOST: string;
   GIT_PROXY_UI_PORT: string | number;
+  GIT_PROXY_COOKIE_SECRET: string | undefined;
+  GIT_PROXY_MONGO_CONNECTION_STRING: string;
 };
 
 const {
@@ -10,6 +12,8 @@ const {
   GIT_PROXY_HTTPS_SERVER_PORT = 8443,
   GIT_PROXY_UI_HOST = 'http://localhost',
   GIT_PROXY_UI_PORT = 8080,
+  GIT_PROXY_COOKIE_SECRET,
+  GIT_PROXY_MONGO_CONNECTION_STRING = 'mongodb://localhost:27017/git-proxy',
 } = process.env;
 
 export const serverConfig: ServerConfig = {
@@ -17,4 +21,6 @@ export const serverConfig: ServerConfig = {
   GIT_PROXY_HTTPS_SERVER_PORT,
   GIT_PROXY_UI_HOST,
   GIT_PROXY_UI_PORT,
+  GIT_PROXY_COOKIE_SECRET,
+  GIT_PROXY_MONGO_CONNECTION_STRING,
 };

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync } from 'fs';
 
 import defaultSettings from '../../proxy.config.json';
+import { serverConfig } from './env';
 import { configFile, validate } from './file';
 import { ConfigLoader, Configuration } from './ConfigLoader';
 import {
@@ -23,7 +24,7 @@ let _apiAuthentication: Authentication[] = defaultSettings.apiAuthentication;
 let _tempPassword: TempPasswordConfig = defaultSettings.tempPassword;
 let _proxyUrl = defaultSettings.proxyUrl;
 let _api: Record<string, unknown> = defaultSettings.api;
-let _cookieSecret: string = defaultSettings.cookieSecret;
+let _cookieSecret: string = serverConfig.GIT_PROXY_COOKIE_SECRET || defaultSettings.cookieSecret;
 let _sessionMaxAgeHours: number = defaultSettings.sessionMaxAgeHours;
 let _plugins: any[] = defaultSettings.plugins;
 let _commitConfig: Record<string, any> = defaultSettings.commitConfig;
@@ -82,6 +83,10 @@ export const getDatabase = () => {
     if (ix) {
       const db = _database[ix];
       if (db.enabled) {
+        // if mongodb is configured and connection string unspecified, fallback to env var
+        if (db.type === 'mongo' && !db.connectionString) {
+          db.connectionString = serverConfig.GIT_PROXY_MONGO_CONNECTION_STRING;
+        }
         return db;
       }
     }
@@ -92,7 +97,7 @@ export const getDatabase = () => {
 
 /**
  * Get the list of enabled authentication methods
- * 
+ *
  * At least one authentication method must be enabled.
  * @return {Authentication[]} List of enabled authentication methods
  */
@@ -104,7 +109,7 @@ export const getAuthMethods = (): Authentication[] => {
   const enabledAuthMethods = _authentication.filter((auth) => auth.enabled);
 
   if (enabledAuthMethods.length === 0) {
-    throw new Error("No authentication method enabled");
+    throw new Error('No authentication method enabled');
   }
 
   return enabledAuthMethods;
@@ -112,7 +117,7 @@ export const getAuthMethods = (): Authentication[] => {
 
 /**
  * Get the list of enabled authentication methods for API endpoints
- * 
+ *
  * If no API authentication methods are enabled, all endpoints are public.
  * @return {Authentication[]} List of enabled authentication methods
  */
@@ -121,10 +126,10 @@ export const getAPIAuthMethods = (): Authentication[] => {
     _apiAuthentication = _userSettings.apiAuthentication;
   }
 
-  const enabledAuthMethods = _apiAuthentication.filter(auth => auth.enabled);
+  const enabledAuthMethods = _apiAuthentication.filter((auth) => auth.enabled);
 
   if (enabledAuthMethods.length === 0) {
-    console.log("Warning: No authentication method enabled for API endpoints.");
+    console.log('Warning: No authentication method enabled for API endpoints.');
   }
 
   return enabledAuthMethods;


### PR DESCRIPTION
Closes #690

- allow for the setting of configuration for MongoDB database
  connection string as well as cookie secret via environment
  variables as an alternative to JSON-based configuration

Useful in environments that split config between secrets (ie.
stored in a secret manager) and plain app configurations such
as commitConfig, attestation, etc. that may not be considered
sensitive & wouldn't be appropriate in a secret manager.
