### PR TITLE
fix: use a public user object to prevent passwords and other secrets …

### DIFF
--- a/src/db/mongo/users.ts
+++ b/src/db/mongo/users.ts
@@ -17,7 +17,7 @@ export const getUsers = async function (query: any = {}) {
   }
   console.log(`Getting users for query= ${JSON.stringify(query)}`);
   const collection = await connect(collectionName);
-  return collection.find(query, { password: 0 }).toArray();
+  return collection.find(query).project({ password: 0 }).toArray();
 };
 
 export const deleteUser = async function (username: string) {

--- a/src/service/routes/users.js
+++ b/src/service/routes/users.js
@@ -2,6 +2,17 @@ const express = require('express');
 const router = new express.Router();
 const db = require('../../db');
 
+const toPublicUser = (user) => {
+  return {
+    username: user.username || '',
+    displayName: user.displayName || '',
+    email: user.email || '',
+    title: user.title || '',
+    gitAccount: user.gitAccount || '',
+    admin: user.admin || false,
+  }
+}
+
 router.get('/', async (req, res) => {
   const query = {};
 
@@ -17,7 +28,8 @@ router.get('/', async (req, res) => {
     query[k] = v;
   }
 
-  res.send(await db.getUsers(query));
+  const users = await db.getUsers(query);
+  res.send(users.map(toPublicUser));
 });
 
 router.get('/:id', async (req, res) => {
@@ -25,8 +37,7 @@ router.get('/:id', async (req, res) => {
   console.log(`Retrieving details for user: ${username}`);
   const data = await db.findUser(username);
   const user = JSON.parse(JSON.stringify(data));
-  if (user && user.password) delete user.password;
-  res.send(user);
+  res.send(toPublicUser(user));
 });
 
 module.exports = router;

--- a/test/services/routes/users.test.js
+++ b/test/services/routes/users.test.js
@@ -1,0 +1,67 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const sinon = require('sinon');
+const express = require('express');
+const usersRouter = require('../../../src/service/routes/users');
+const db = require('../../../src/db');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+describe('Users API', function () {
+  let app;
+
+  before(function () {
+    app = express();
+    app.use(express.json());
+    app.use('/users', usersRouter);
+  });
+
+  beforeEach(function () {
+    sinon.stub(db, 'getUsers').resolves([
+      {
+        username: 'alice',
+        password: 'secret-hashed-password',
+        email: 'alice@example.com',
+        displayName: 'Alice Walker',
+      },
+    ]);
+    sinon
+      .stub(db, 'findUser')
+      .resolves({ username: 'bob', password: 'hidden', email: 'bob@example.com' });
+  });
+
+  afterEach(function () {
+    sinon.restore();
+  });
+
+  it('GET /users only serializes public data needed for ui, not user secrets like password', async function () {
+    const res = await chai.request(app).get('/users');
+    expect(res).to.have.status(200);
+    expect(res.body).to.deep.equal([
+      {
+        username: 'alice',
+        displayName: 'Alice Walker',
+        email: 'alice@example.com',
+        title: '',
+        gitAccount: '',
+        admin: false,
+      },
+    ]);
+  });
+
+  it('GET /users/:id does not serialize password', async function () {
+    const res = await chai.request(app).get('/users/bob');
+    expect(res).to.have.status(200);
+    console.log(`Response body: ${res.body}`);
+
+    expect(res.body).to.deep.equal({
+      username: 'bob',
+      displayName: '',
+      email: 'bob@example.com',
+      title: '',
+      gitAccount: '',
+      admin: false,
+    });
+  });
+});

--- a/test/testDb.test.js
+++ b/test/testDb.test.js
@@ -241,7 +241,7 @@ describe('Database clients', async () => {
       TEST_USER.admin,
     );
 
-    // has less properties to prove that records are merged
+    // has fewer properties to prove that records are merged
     const updateToApply = {
       username: TEST_USER.username,
       gitAccount: 'updatedGitAccount',


### PR DESCRIPTION
# Summary

A recent penetration test identified that the `/api/v1/user` endpoint exposes **sensitive internal user data**, including:

- Password hashes
- Okta authentication IDs
- Internal database identifiers (_id)
- Other fields not intended for the UI

## Root Cause

The API response was serializing raw user objects directly from the database, without filtering or transforming the fields. A previous fix attempt ([#741](https://github.com/finos/git-proxy/pull/741)) tried to exclude the password field using:

`
collection.find(query, { password: 0 }).toArray();
`

However, this projection syntax is no longer valid in MongoDB Node.js Driver v5, where the second argument to `find()` must be an explicit FindOptions object. As a result, the fix was ineffective, and sensitive fields continued to be returned.

## Fix

This PR addresses the issue on two levels:

1.  **Corrects the MongoDB projection syntax** so that password fields are properly excluded:

```
collection.find(query).project({ password: 0 }).toArray();
```

2. **Introduces a public-facing serialisation object** to explicitly control which user fields are returned to the UI. Instead of returning raw database user objects, each user is now mapped to a PublicUser shape that includes only the fields required by the frontend. All internal and sensitive fields are explicitly excluded by design.
