### PR TITLE
fix: prevent non-admin users changing another user's gitAccount

### DIFF
--- a/src/service/routes/auth.js
+++ b/src/service/routes/auth.js
@@ -136,7 +136,7 @@ router.post('/gitAccount', async (req, res) => {
       }
 
       const reqUser = await db.findUser(req.user.username);
-      if(username !== reqUser.username && !reqUser.admin) {
+      if (username !== reqUser.username && !reqUser.admin) {
         res.status(403).send('Error: You must be an admin to update a different account').end();
         return;
       }

--- a/src/service/routes/auth.js
+++ b/src/service/routes/auth.js
@@ -135,8 +135,12 @@ router.post('/gitAccount', async (req, res) => {
         return;
       }
 
+      const reqUser = await db.findUser(req.user.username);
+      if(username !== reqUser.username && !reqUser.admin) {
+        res.status(403).send('Error: You must be an admin to update a different account').end();
+        return;
+      }
       const user = await db.findUser(username);
-
       console.log('Adding gitAccount' + req.body.gitAccount);
       user.gitAccount = req.body.gitAccount;
       db.updateUser(user);

--- a/test/services/routes/auth.test.js
+++ b/test/services/routes/auth.test.js
@@ -1,0 +1,116 @@
+const chai = require('chai');
+const chaiHttp = require('chai-http');
+const sinon = require('sinon');
+const express = require('express');
+const authRouter = require('../../../src/service/routes/auth');
+const db = require('../../../src/db');
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+const newApp = (username) => {
+  const app = express();
+  app.use(express.json());
+
+  if (username) {
+    app.use((req, res, next) => {
+      req.user = { username };
+      next();
+    });
+  }
+
+  app.use('/auth', authRouter);
+  return app;
+};
+
+describe('Authentication Routes', () => {
+  describe('/gitAccount', () => {
+    beforeEach(() => {
+      sinon.stub(db, 'findUser').callsFake((username) => {
+        if (username === 'alice') {
+          return Promise.resolve({
+            username: 'alice',
+            displayName: 'Alice Munro',
+            gitAccount: 'ORIGINAL_GIT_ACCOUNT',
+            email: 'alice@example.com',
+            admin: true,
+          });
+        } else if (username === 'bob') {
+          return Promise.resolve({
+            username: 'bob',
+            displayName: 'Bob Woodward',
+            gitAccount: 'WOODY_GIT_ACCOUNT',
+            email: 'bob@example.com',
+            admin: false,
+          });
+        }
+        return Promise.resolve(null);
+      });
+    });
+
+    afterEach(() => {
+      sinon.restore();
+    });
+
+    it('POST /gitAccount returns Unauthorized if authenticated user not in request', async () => {
+      const res = await chai.request(newApp()).post('/auth/gitAccount').send({
+        username: 'alice',
+        gitAccount: '',
+      });
+
+      expect(res).to.have.status(401);
+    });
+
+    it('POST /gitAccount updates git account for authenticated user', async () => {
+      const updateUserStub = sinon.stub(db, 'updateUser').resolves();
+
+      const res = await chai.request(newApp('alice')).post('/auth/gitAccount').send({
+        username: 'alice',
+        gitAccount: 'UPDATED_GIT_ACCOUNT',
+      });
+
+      expect(res).to.have.status(200);
+      expect(
+        updateUserStub.calledOnceWith({
+          username: 'alice',
+          displayName: 'Alice Munro',
+          gitAccount: 'UPDATED_GIT_ACCOUNT',
+          email: 'alice@example.com',
+          admin: true,
+        }),
+      ).to.be.true;
+    });
+
+    it('POST /gitAccount prevents non-admin user changing a different user gitAccount', async () => {
+      const updateUserStub = sinon.stub(db, 'updateUser').resolves();
+
+      const res = await chai.request(newApp('bob')).post('/auth/gitAccount').send({
+        username: 'phil',
+        gitAccount: 'UPDATED_GIT_ACCOUNT',
+      });
+
+      expect(res).to.have.status(403);
+      expect(updateUserStub.called).to.be.false;
+    });
+
+    it('POST /gitAccount lets admin user change a different users gitAccount', async () => {
+      const updateUserStub = sinon.stub(db, 'updateUser').resolves();
+
+      const res = await chai.request(newApp('alice')).post('/auth/gitAccount').send({
+        username: 'bob',
+        gitAccount: 'UPDATED_GIT_ACCOUNT',
+      });
+
+      expect(res).to.have.status(200);
+      expect(
+        updateUserStub.calledOnceWith({
+          username: 'bob',
+          displayName: 'Bob Woodward',
+          email: 'bob@example.com',
+          admin: false,
+          gitAccount: 'UPDATED_GIT_ACCOUNT',
+        }),
+      ).to.be.true;
+    });
+  });
+});

--- a/test/services/routes/auth.test.js
+++ b/test/services/routes/auth.test.js
@@ -112,5 +112,26 @@ describe('Authentication Routes', () => {
         }),
       ).to.be.true;
     });
+    
+    it('POST /gitAccount allows non-admin user to update their own gitAccount', async () => {
+      const updateUserStub = sinon.stub(db, 'updateUser').resolves();
+
+      const res = await chai.request(newApp('bob')).post('/auth/gitAccount').send({
+        username: 'bob',
+        gitAccount: 'UPDATED_GIT_ACCOUNT',
+      });
+
+      expect(res).to.have.status(200);
+      expect(
+        updateUserStub.calledOnceWith({
+          username: 'bob',
+          displayName: 'Bob Woodward',
+          email: 'bob@example.com',
+          admin: false,
+          gitAccount: 'UPDATED_GIT_ACCOUNT',
+        }),
+      ).to.be.true;
+    });
+
   });
 });


### PR DESCRIPTION
# Summary

A recent penetration test identified a security issue in the `/api/v1/auth/gitAccount` endpoint:

- Users can add or update their own GitHub/GitLab account names.
- Admins can add or update GitHub/GitLab account names for any user.
- However, **the API does not enforce this restriction** — any user can change the Git account name for any other user, regardless of their permissions.

## Root Cause

The API only checks that the requester is authenticated; it does not verify whether the user is updating their own account or has admin privileges.


## Fix

This PR introduces a guard clause that ensures the requesting user is either:

- Updating their own Git account
- Has admin privileges.

This change brings the backend access control in line with the intended behaviour already enforced in the UI.

I’ve added a new `auth.test.js`. I chose not to expand the existing `testLogin.test.js` because I wanted to test at a lower level, where I can directly assert that the database is updated as expected.

While the current endpoint lives under /auth, updating a user's Git account may conceptually belong on the /user endpoint. However, this change is out of scope for this fix and has been deferred.