### PR TITLE
fix: prevent DOS when checking an unknown repo

### DIFF
--- a/src/db/mongo/repo.ts
+++ b/src/db/mongo/repo.ts
@@ -79,19 +79,19 @@ export const deleteRepo = async (name: string) => {
 export const isUserPushAllowed = async (name: string, user: string) => {
   name = name.toLowerCase();
   user = user.toLowerCase();
+  console.log(`checking if user ${user} can push to ${name}`);
   return new Promise(async (resolve) => {
     const repo = await exports.getRepo(name);
-    console.log(repo.users.canPush);
-    console.log(repo.users.canAuthorise);
-
-    if (repo.users.canPush.includes(user) || repo.users.canAuthorise.includes(user)) {
-      resolve(true);
-    } else {
+    if( !repo ) {
+      console.log(`repo ${name} not found`);
       resolve(false);
+      return;
     }
+    resolve(repo.users.canPush.includes(user) || repo.users.canAuthorise.includes(user));
   });
 };
 
+// not used in the codebase, but kept for compatibility
 export const canUserApproveRejectPushRepo = async (name: string, user: string) => {
   name = name.toLowerCase();
   user = user.toLowerCase();

--- a/test/db/mongo/repo.test.js
+++ b/test/db/mongo/repo.test.js
@@ -1,0 +1,52 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const repoModule = require('../../../src/db/mongo/repo');
+
+const { expect } = chai;
+
+describe('mongo repo', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  describe('isUserPushAllowed', () => {
+    it('returns true if user is in canPush', async () => {
+      sinon.stub(repoModule, 'getRepo').resolves({
+        users: {
+          canPush: ['alice'],
+          canAuthorise: [],
+        },
+      });
+      const result = await repoModule.isUserPushAllowed('myrepo', 'alice');
+      expect(result).to.be.true;
+    });
+
+    it('returns true if user is in canAuthorise', async () => {
+      sinon.stub(repoModule, 'getRepo').resolves({
+        users: {
+          canPush: [],
+          canAuthorise: ['bob'],
+        },
+      });
+      const result = await repoModule.isUserPushAllowed('myrepo', 'bob');
+      expect(result).to.be.true;
+    });
+
+    it('returns false if user is in neither', async () => {
+      sinon.stub(repoModule, 'getRepo').resolves({
+        users: {
+          canPush: [],
+          canAuthorise: [],
+        },
+      });
+      const result = await repoModule.isUserPushAllowed('myrepo', 'charlie');
+      expect(result).to.be.false;
+    });
+
+    it('returns false if repo is not registered', async () => {
+      sinon.stub(repoModule, 'getRepo').resolves(null);
+      const result = await repoModule.isUserPushAllowed('myrepo', 'charlie');
+      expect(result).to.be.false;
+    });
+  });
+});


### PR DESCRIPTION
# Summary

This PR fixes a potential denial-of-service (DoS) vulnerability:

When pushing to an unknown repository, the MongoDB implementation throws a TypeError due to attempting to access properties on a null object:

```
console.log(repo.users.canPush);
// TypeError: Cannot read properties of null (reading 'users')
```

## Root Cause

The file-based database implementation correctly checks for the existence of a repository before accessing its fields. However, the MongoDB implementation does not.

Specifically, `checkUserPushPermission` calls `isUserPushAllowed`, which assumes the repository exists. If the repository is not found, accessing its properties throws a TypeError and stops the service.

## Fix

This PR addresses the issue by:

- Adding  a guard clause in the MongoDB implementation of `isUserPushAllowed` to handle missing repositories safely.

- Adds a unit test to verify behaviour when the repository does not exist.
