### PR TITLE
chore: bump by patch to v1.19.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/git-proxy",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/git-proxy",
-      "version": "1.19.0",
+      "version": "1.19.1",
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/git-proxy-cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy",
-  "version": "1.19.0",
+  "version": "1.19.1",
   "description": "Deploy custom push protections and policies on top of Git.",
   "scripts": {
     "cli": "node ./packages/git-proxy-cli/index.js",


### PR DESCRIPTION
~Preparing release of `v1.19.1`.~

I accidentally pushed to my remote first, will reopen this in an upstream branch for visibility.