### PR TITLE
docs: update SECURITY.md with reporting guidance

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,13 @@
-## Reporting a vulnerability
+# Security Policy
 
-If you discover a vulnerability in git-proxy, please e-mail [opensource@citi.com](mailto:opensource@citi.com).
+GitProxy supports responsible disclosure of security vulnerabilities and adheres to the [FINOS Security Vulnerabilities Policy](https://community.finos.org/docs/governance/Software-Projects/cve-responsible-disclosure). If you find something you believe to be a security issue in GitProxy, we encourage and appreciate your report. Please report the issue privately to the project maintainers using one of the following methods:
 
-Thank you for improving the security of git-proxy.
+## Reporting a Vulnerability
+- **GitHub Security Reports:** In order for the vulnerability reports to reach maintainers as soon as possible, the preferred way is to use the ["Report a vulnerability"](https://github.com/finos/git-proxy/security/advisories) button under the "Security" tab of the associated GitHub project. This creates a private communication channel between the reporter and the maintainers.  
+- **Email:** If you are unable to or have strong reasons not to use the GitHub Security vulnerability reporting feature, please email the maintainers and cc: [security@finos.org](mailto:security@finos.org) with a description of the vulnerability.
+
+## Vulnerability Process
+
+1. **Report the vulnerability privately** using one of the methods above. Do not create a public GitHub Issue or make any public reference to the vulnerability.
+2. The project team will acknowledge receipt of your report and triage the issue. If a vulnerability is confirmed, the team will work with you to investigate and resolve it.
+3. Once a fix is available, a release will be made and the vulnerability will be publicly disclosed in accordance with the [FINOS policy](https://community.finos.org/docs/governance/Software-Projects/cve-responsible-disclosure).


### PR DESCRIPTION
Clarifies the preferred vulnerability disclosure process by directing users to report via GitHub and linking to the FINOS security vulnerabilities policy.

Closes [1018](https://github.com/finos/git-proxy/issues/1018)
