### PR TITLE
Fix display repo add errors

### DIFF
--- a/cypress/e2e/repo.cy.js
+++ b/cypress/e2e/repo.cy.js
@@ -1,57 +1,119 @@
 describe('Repo', () => {
   beforeEach(() => {
-    cy.login('admin', 'admin');
-
     cy.visit('/dashboard/repo');
 
     // prevent failures on 404 request and uncaught promises
     cy.on('uncaught:exception', () => false);
   });
 
-  describe('Code button for repo row', () => {
-    it('Opens tooltip with correct content and can copy', () => {
-      const cloneURL = 'http://localhost:8000/finos/git-proxy.git';
-      const tooltipQuery = 'div[role="tooltip"]';
-
-      cy
-        // tooltip isn't open to start with
-        .get(tooltipQuery)
+  describe('Anonymous users', () => {
+    it('Prevents anonymous users from adding repos', () => {
+      cy.get('[data-testid="repo-list-view"]')
+        .find('[data-testid="add-repo-button"]')
         .should('not.exist');
+    });
 
-      cy
-        // find the entry for finos/git-proxy
-        .get('a[href="/dashboard/repo/git-proxy"]')
-        // take it's parent row
-        .closest('tr')
-        // find the nearby span containing Code we can click to open the tooltip
-        .find('span')
-        .contains('Code')
-        .should('exist')
-        .click();
+    describe('Code button for repo row', () => {
+      it('Opens tooltip with correct content and can copy', () => {
+        const cloneURL = 'http://localhost:8000/finos/git-proxy.git';
+        const tooltipQuery = 'div[role="tooltip"]';
 
-      cy
-        // find the newly opened tooltip
-        .get(tooltipQuery)
-        .should('exist')
-        .find('span')
-        // check it contains the url we expect
-        .contains(cloneURL)
-        .should('exist')
-        .parent()
-        // find the adjacent span that contains the svg
-        .find('span')
-        .next()
-        // check it has the copy icon first and click it
-        .get('svg.octicon-copy')
-        .should('exist')
-        .click()
-        // check the icon has changed to the check icon
-        .get('svg.octicon-copy')
-        .should('not.exist')
-        .get('svg.octicon-check')
-        .should('exist');
+        cy
+          // tooltip isn't open to start with
+          .get(tooltipQuery)
+          .should('not.exist');
 
-      // failed to successfully check the clipboard
+        cy
+          // find the entry for finos/git-proxy
+          .get('a[href="/dashboard/repo/git-proxy"]')
+          // take it's parent row
+          .closest('tr')
+          // find the nearby span containing Code we can click to open the tooltip
+          .find('span')
+          .contains('Code')
+          .should('exist')
+          .click();
+
+        cy
+          // find the newly opened tooltip
+          .get(tooltipQuery)
+          .should('exist')
+          .find('span')
+          // check it contains the url we expect
+          .contains(cloneURL)
+          .should('exist')
+          .parent()
+          // find the adjacent span that contains the svg
+          .find('span')
+          .next()
+          // check it has the copy icon first and click it
+          .get('svg.octicon-copy')
+          .should('exist')
+          .click()
+          // check the icon has changed to the check icon
+          .get('svg.octicon-copy')
+          .should('not.exist')
+          .get('svg.octicon-check')
+          .should('exist');
+
+        // failed to successfully check the clipboard
+      });
+    });
+  });
+
+  describe('Regular users', () => {
+    beforeEach(() => {
+      cy.login('user', 'user');
+
+      cy.visit('/dashboard/repo');
+    });
+
+    after(() => {
+      cy.logout();
+    });
+
+    it('Prevents regular users from adding repos', () => {
+      cy.get('[data-testid="repo-list-view"]')
+        .find('[data-testid="add-repo-button"]')
+        .should('not.exist');
+    });
+  });
+
+  describe('Admin users', () => {
+    beforeEach(() => {
+      cy.login('admin', 'admin');
+
+      cy.visit('/dashboard/repo');
+    });
+
+    it('Admin users can add repos', () => {
+      cy.get('[data-testid="repo-list-view"]').find('[data-testid="add-repo-button"]').click();
+
+      cy.get('[data-testid="add-repo-dialog"]').within(() => {
+        cy.get('[data-testid="repo-project-input"]').type('uuidjs');
+        cy.get('[data-testid="repo-name-input"]').type('uuidjs');
+        cy.get('[data-testid="repo-url-input"]').type('https://github.com/uuidjs/uuid.git');
+        cy.get('[data-testid="add-repo-button"]').click();
+      });
+
+      cy.get('a[href="/dashboard/repo/uuidjs"]', { timeout: 10000 }).click();
+
+      cy.get('[data-testid="delete-repo-button"]').click();
+    });
+
+    it('Prevents adding an existing repo', () => {
+      cy.get('[data-testid="repo-list-view"]').find('[data-testid="add-repo-button"]').click();
+
+      cy.get('[data-testid="add-repo-dialog"]').within(() => {
+        cy.get('[data-testid="repo-project-input"]').type('finos');
+        cy.get('[data-testid="repo-name-input"]').type('git-proxy');
+        cy.get('[data-testid="repo-url-input"]').type('https://github.com/finos/git-proxy.git');
+        cy.get('[data-testid="add-repo-button"]').click();
+      });
+
+      cy.get('[data-testid="repo-error"]')
+        .should('be.visible')
+        .and('contain.text', 'Repository already exists!');
     });
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -39,3 +39,7 @@ Cypress.Commands.add('login', (username, password) => {
     cy.url().should('include', '/dashboard/repo');
   });
 });
+
+Cypress.Commands.add('logout', () => {
+   Cypress.session.clearAllSavedSessions();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "@vitejs/plugin-react": "^4.0.2",
         "chai": "^4.2.0",
         "chai-http": "^4.3.0",
-        "cypress": "^14.0.0",
+        "cypress": "^14.5.2",
         "eslint": "^8.57.0",
         "eslint-config-google": "^0.14.0",
         "eslint-config-prettier": "^10.0.1",
@@ -1267,16 +1267,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@colors/colors": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
-      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "19.6.1",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-19.6.1.tgz",
@@ -1698,9 +1688,9 @@
       }
     },
     "node_modules/@cypress/request": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.6.tgz",
-      "integrity": "sha512-fi0eVdCOtKu5Ed6+E8mYxUF6ZTFJDZvHogCBelM0xVXmrDEkyM22gRArQzq1YcHPm1V47Vf/iAD+WgVdUlJCGg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@cypress/request/-/request-3.0.9.tgz",
+      "integrity": "sha512-I3l7FdGRXluAS44/0NguwWlO83J18p0vlr2FYHrJkWdNYhgVoiYo61IXPqaOsL+vNxU1ZqMACzItGK3/KKDsdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -1710,14 +1700,14 @@
         "combined-stream": "~1.0.6",
         "extend": "~3.0.2",
         "forever-agent": "~0.6.1",
-        "form-data": "~4.0.0",
+        "form-data": "~4.0.4",
         "http-signature": "~1.4.0",
         "is-typedarray": "~1.0.0",
         "isstream": "~0.1.2",
         "json-stringify-safe": "~5.0.1",
         "mime-types": "~2.1.19",
         "performance-now": "^2.1.0",
-        "qs": "6.13.0",
+        "qs": "6.14.0",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "^5.0.0",
         "tunnel-agent": "^0.6.0",
@@ -1727,11 +1717,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/@cypress/request/node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/@cypress/request/node_modules/uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "dev": true,
+      "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -4673,15 +4680,17 @@
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
       "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/aws4": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.0.tgz",
-      "integrity": "sha512-3AungXC4I8kKsS9PuS4JH2nc+0bVY/mjgrephHTIi8fpEeGsTHBUJeosp0Wc1myYMElmD0B3Oc4XL/HVJ4PV2g==",
-      "dev": true
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
+      "integrity": "sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/axios": {
       "version": "1.10.0",
@@ -5029,7 +5038,8 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
-      "dev": true
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/chai": {
       "version": "4.5.0",
@@ -5167,15 +5177,16 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.0.0.tgz",
-      "integrity": "sha512-TdHqgGf9odd8SXNuxtUBVx8Nv+qZOejE6qyqiy5NtbYYQOeFa6zmHkxlPzmaLxWWHsU6nJmB7AETdVPi+2NBUg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/sibiraj-s"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -5212,10 +5223,11 @@
       }
     },
     "node_modules/cli-table3": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
-      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
       },
@@ -5223,20 +5235,22 @@
         "node": "10.* || >= 12.*"
       },
       "optionalDependencies": {
-        "@colors/colors": "1.5.0"
+        "colors": "1.4.0"
       }
     },
     "node_modules/cli-table3/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cli-table3/node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5360,6 +5374,17 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
       "integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
       "dev": true
+    },
+    "node_modules/colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -5658,14 +5683,14 @@
       "integrity": "sha512-Z1PhmomIfypOpoMjRQB70jfvy/wxT50qW08YXO5lMIJkrdq4yOTR+AW7FqutScmB9NkLwxo+jU+kZLbofZZq/w=="
     },
     "node_modules/cypress": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.0.0.tgz",
-      "integrity": "sha512-kEGqQr23so5IpKeg/dp6GVi7RlHx1NmW66o2a2Q4wk9gRaAblLZQSiZJuDI8UMC4LlG5OJ7Q6joAiqTrfRNbTw==",
+      "version": "14.5.3",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-14.5.3.tgz",
+      "integrity": "sha512-syLwKjDeMg77FRRx68bytLdlqHXDT4yBVh0/PPkcgesChYDjUZbwxLqMXuryYKzAyJsPsQHUDW1YU74/IYEUIA==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@cypress/request": "^3.0.6",
+        "@cypress/request": "^3.0.9",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -5676,9 +5701,9 @@
         "cachedir": "^2.3.0",
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
-        "ci-info": "^4.0.0",
+        "ci-info": "^4.1.0",
         "cli-cursor": "^3.1.0",
-        "cli-table3": "~0.6.1",
+        "cli-table3": "0.6.1",
         "commander": "^6.2.1",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
@@ -5691,6 +5716,7 @@
         "figures": "^3.2.0",
         "fs-extra": "^9.1.0",
         "getos": "^3.2.1",
+        "hasha": "5.2.2",
         "is-installed-globally": "~0.4.0",
         "lazy-ass": "^1.6.0",
         "listr2": "^3.8.3",
@@ -5702,7 +5728,7 @@
         "process": "^0.11.10",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.5.3",
+        "semver": "^7.7.1",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.3",
         "tree-kill": "1.2.2",
@@ -5724,9 +5750,9 @@
       "license": "MIT"
     },
     "node_modules/cypress/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -6341,7 +6367,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7136,7 +7161,8 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/extended-emitter": {
       "version": "1.6.0",
@@ -7487,17 +7513,21 @@
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
       "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "*"
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -8953,7 +8983,8 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -9261,7 +9292,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
-      "dev": true
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -11253,7 +11285,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.0",
@@ -13009,22 +13042,22 @@
       "license": "MIT"
     },
     "node_modules/tldts": {
-      "version": "6.1.65",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.65.tgz",
-      "integrity": "sha512-xU9gLTfAGsADQ2PcWee6Hg8RFAv0DnjMGVJmDnUmI8a9+nYmapMQix4afwrdaCtT+AqP4MaxEzu7cCrYmBPbzQ==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^6.1.65"
+        "tldts-core": "^6.1.86"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "6.1.65",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.65.tgz",
-      "integrity": "sha512-Uq5t0N0Oj4nQSbU8wFN1YYENvMthvwU13MQrMJRspYCGLSAZjAfoBOJki5IQpnBM/WFskxxC/gIOTwaedmHaSg==",
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
     },
@@ -13058,9 +13091,9 @@
       }
     },
     "node_modules/tough-cookie": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.0.0.tgz",
-      "integrity": "sha512-FRKsF7cz96xIIeMZ82ehjC3xW2E+O2+v11udrDYewUbszngYhsGa8z6YUMMzO9QJZzzyd0nGGXnML/TReX6W8Q==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13625,6 +13658,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint:fix": "eslint --fix \"src/**/*.{js,jsx,ts,tsx,json}\" \"test/**/*.{js,jsx,ts,tsx,json}\"",
     "format": "prettier --write src/**/*.{js,jsx,ts,tsx,css,md,json,scss} test/**/*.{js,jsx,ts,tsx,json} packages/git-proxy-cli/test/**/*.{js,jsx,ts,tsx,json}  packages/git-proxy-cli/index.js --config ./.prettierrc",
     "gen-schema-doc": "node ./scripts/doc-schema.js",
-    "cypress:run": "cypress run"
+    "cypress:run": "cypress run",
+    "cypress:open": "cypress open"
   },
   "bin": {
     "git-proxy": "./index.js",
@@ -102,7 +103,7 @@
     "@vitejs/plugin-react": "^4.0.2",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
-    "cypress": "^14.0.0",
+    "cypress": "^14.5.2",
     "eslint": "^8.57.0",
     "eslint-config-google": "^0.14.0",
     "eslint-config-prettier": "^10.0.1",

--- a/src/service/passport/local.js
+++ b/src/service/passport/local.js
@@ -42,13 +42,18 @@ const configure = async (passport) => {
 };
 
 /**
- * Create the default admin user if it doesn't exist
+ * Create the default admin and regular test users.
  */
 const createDefaultAdmin = async () => {
-  const admin = await db.findUser("admin");
-  if (!admin) {
-    await db.createUser("admin", "admin", "admin@place.com", "none", true);
-  }
+  const createIfNotExists = async (username, password, email, type, isAdmin) => {
+    const user = await db.findUser(username);
+    if (!user) {
+      await db.createUser(username, password, email, type, isAdmin);
+    }
+  };
+
+  await createIfNotExists('admin', 'admin', 'admin@place.com', 'none', true);
+  await createIfNotExists('user', 'user', 'user@place.com', 'none', false);
 };
 
 module.exports = { configure, createDefaultAdmin, type };

--- a/src/ui/services/repo.js
+++ b/src/ui/services/repo.js
@@ -81,17 +81,17 @@ const getRepo = async (setIsLoading, setData, setAuth, setIsError, id) => {
     });
 };
 
-const addRepo = async (onClose, setError, data) => {
+const addRepo = async (data) => {
   const url = new URL(`${baseUrl}/repo`);
-  axios
-    .post(url, data, { withCredentials: true, headers: { 'X-CSRF-TOKEN': getCookie('csrf') } })
-    .then(() => {
-      onClose();
-    })
-    .catch((error) => {
-      console.log(error.response.data.message);
-      setError(error.response.data.message);
-    });
+  try {
+    await axios.post(url, data, { withCredentials: true, headers: { 'X-CSRF-TOKEN': getCookie('csrf') } });
+    return { success: true };
+  } catch (error) {
+    return {
+      success: false,
+      message: error.response?.data?.message || error.message
+    };
+  }
 };
 
 const addUser = async (repoName, user, action) => {

--- a/src/ui/views/RepoDetails/RepoDetails.tsx
+++ b/src/ui/views/RepoDetails/RepoDetails.tsx
@@ -101,6 +101,7 @@ const RepoDetails: React.FC = () => {
                 <Button
                   variant='contained'
                   color='secondary'
+                  data-testid='delete-repo-button'
                   onClick={() => removeRepository(data.name)}
                 >
                   <Delete />

--- a/src/ui/views/RepoList/Components/NewRepo.tsx
+++ b/src/ui/views/RepoList/Components/NewRepo.tsx
@@ -89,16 +89,12 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
       return;
     }
 
-    try {
-      await addRepo(onClose, setError, data);
+    const result = await addRepo(data);
+    if (result.success) {
       handleSuccess(data);
       handleClose();
-    } catch (e) {
-      if (e instanceof Error) {
-        setError(e.message);
-      } else {
-        setError('An unexpected error occurred');
-      }
+    } else {
+      setError(result.message || 'Failed to add repository');
     }
   };
 
@@ -126,7 +122,7 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
         maxWidth='md'
       >
         {error && (
-          <DialogTitle style={{ color: 'red' }} id='simple-dialog-title'>
+          <DialogTitle style={{ color: 'red' }} data-testid='repo-error'>
             {error}
           </DialogTitle>
         )}
@@ -135,13 +131,14 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
         </DialogTitle>
         <Card>
           <CardBody>
-            <GridContainer>
+            <GridContainer data-testid='add-repo-dialog'>
               <GridItem xs={12} sm={12} md={12}>
                 <FormControl style={inputStyle}>
                   <InputLabel htmlFor='project'>Organization</InputLabel>
                   <Input
                     id='project'
                     inputProps={{ maxLength: 200, minLength: 3 }}
+                    data-testid='repo-project-input'
                     aria-describedby='project-helper-text'
                     onChange={(e) => setProject(e.target.value)}
                     value={project}
@@ -155,6 +152,7 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
                   <Input
                     inputProps={{ maxLength: 200, minLength: 3 }}
                     id='name'
+                    data-testid='repo-name-input'
                     aria-describedby='name-helper-text'
                     onChange={(e) => setName(e.target.value)}
                     value={name}
@@ -170,6 +168,7 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
                     type='url'
                     id='url'
                     aria-describedby='url-helper-text'
+                    data-testid='repo-url-input'
                     onChange={(e) => setUrl(e.target.value)}
                     value={url}
                   />
@@ -181,7 +180,7 @@ const AddRepositoryDialog: React.FC<AddRepositoryDialogProps> = ({ open, onClose
                   <Button variant='outlined' color='warning' onClick={handleClose}>
                     Cancel
                   </Button>
-                  <Button variant='outlined' color='success' onClick={add}>
+                  <Button variant='outlined' color='success' onClick={add} data-testid='add-repo-button'>
                     Add
                   </Button>
                 </div>
@@ -207,7 +206,7 @@ const NewRepo: React.FC<NewRepoProps> = ({ onSuccess }) => {
 
   return (
     <div>
-      <Button color='success' onClick={handleClickOpen}>
+      <Button color='success' onClick={handleClickOpen} data-testid='add-repo-button'>
         <RepoIcon /> Add repository
       </Button>
       <AddRepositoryDialog open={open} onClose={handleClose} onSuccess={onSuccess} />

--- a/src/ui/views/RepoList/Components/TabList.tsx
+++ b/src/ui/views/RepoList/Components/TabList.tsx
@@ -5,7 +5,7 @@ import Repositories from './Repositories';
 
 export default function Dashboard(): React.ReactElement {
   return (
-    <div>
+    <div data-testid="repo-list-view">
       <GridContainer>
         <GridItem xs={12} sm={12} md={12}>
           <Repositories />


### PR DESCRIPTION
# Summary

This PR fixes a bug where the client silently ignored server-side errors when adding a new repository. As a result, users were led to believe the repository was added successfully, only to see it disappear upon refreshing the page.

## Root Cause

The `NewRepo.tsx` component (`src/ui/views/RepoList/Components/NewRepo.tsx`) always closed the modal, regardless of whether the server request succeeded or failed.

## Fix

Display server errors returned by addRepo in `src/ui/services/repo.js`.

Extended Cypress tests to:

- Reproduce the bug.
- Verify the fix.
- Upgraded Cypress to version 14.5.2.
- Added data-testid attributes to improve selector stability in Cypress tests (avoids coupling to CSS/JS changes). These are are also useful in the react unit tests (see note)

## Notes

Adding unit tests for the React components is desirable but considered out of scope for this PR.

