### PR TITLE
chore: bump version to rc.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/git-proxy",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/git-proxy",
-      "version": "2.0.0-rc.1",
+      "version": "2.0.0-rc.2",
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/git-proxy-cli"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.2",
   "description": "Deploy custom push protections and policies on top of Git.",
   "scripts": {
     "cli": "node ./packages/git-proxy-cli/index.js",

--- a/test/ConfigLoader.test.js
+++ b/test/ConfigLoader.test.js
@@ -331,7 +331,6 @@ describe('ConfigLoader', () => {
 
       // Verify the loaded config has expected structure
       expect(config).to.be.an('object');
-      expect(config).to.have.property('proxyUrl');
       expect(config).to.have.property('cookieSecret');
     });
 
@@ -381,7 +380,6 @@ describe('ConfigLoader', () => {
 
       // Verify the loaded config has expected structure
       expect(config).to.be.an('object');
-      expect(config).to.have.property('proxyUrl');
       expect(config).to.have.property('cookieSecret');
     });
 


### PR DESCRIPTION
For the `rc.2` prerelease containing changes in #1043.

Also fixes two failing tests due to a removed config entry.