### PR TITLE
feat: don't forward requests for unknown repos

### DIFF
--- a/src/proxy/chain.ts
+++ b/src/proxy/chain.ts
@@ -45,6 +45,10 @@ export const executeChain = async (req: any, res: any): Promise<Action> => {
         return action;
       }
     }
+  } catch (e) {
+    action.error = true;
+    action.errorMessage = `An error occurred when executing the chain: ${e}`;
+    console.error(action.errorMessage);
   } finally {
     await proc.push.audit(req, action);
     if (action.autoApproved) {

--- a/src/proxy/processors/pre-processor/parseAction.ts
+++ b/src/proxy/processors/pre-processor/parseAction.ts
@@ -14,8 +14,7 @@ const exec = async (req: {
   if (pathBreakdown) {
     if (pathBreakdown.gitPath.endsWith('git-upload-pack') && req.method === 'GET') {
       type = 'pull';
-    }
-    if (
+    } else if (
       pathBreakdown.gitPath.includes('git-receive-pack') &&
       req.method === 'POST' &&
       req.headers['content-type'] === 'application/x-git-receive-pack-request'

--- a/test/chain.test.js
+++ b/test/chain.test.js
@@ -95,6 +95,8 @@ describe('proxy chain', function () {
 
   afterEach(() => {
     // Clear the module from the cache after each test
+    sandboxSinon.restore();
+    sinon.restore();
     clearCache(sandboxSinon);
   });
 

--- a/test/chain.test.js
+++ b/test/chain.test.js
@@ -277,17 +277,15 @@ describe('proxy chain', function () {
     expect(mockPushProcessors.audit.called).to.be.true;
   });
 
-  it('executeChain should run no actions if not a push or pull', async function () {
+  it('executeChain should always run at least checkRepoInAuthList', async function () {
     const req = {};
     const action = { type: 'foo', continue: () => true, allowPush: true };
 
-    processors.pre.parseAction.resolves(action);
+    mockPreProcessors.parseAction.resolves(action);
+    mockPushProcessors.checkRepoInAuthorisedList.resolves(action);
 
-    const result = await chain.executeChain(req);
-
-    expect(mockPushProcessors.checkRepoInAuthorisedList.called).to.be.false;
-    expect(mockPushProcessors.parsePush.called).to.be.false;
-    expect(result).to.deep.equal(action);
+    await chain.executeChain(req);
+    expect(mockPushProcessors.checkRepoInAuthorisedList.called).to.be.true;
   });
 
   it('should approve push automatically and record in the database', async function () {

--- a/test/teeAndValidation.test.js
+++ b/test/teeAndValidation.test.js
@@ -56,7 +56,7 @@ describe('teeAndValidate middleware', () => {
     expect(next.called).to.be.false;
 
     expect(res.set.called).to.be.true;
-    expect(res.status.calledWith(200)).to.be.true;
+    expect(res.status.calledWith(403)).to.be.true;
     expect(res.send.calledWith(handleMessage('denied!'))).to.be.true;
   });
 

--- a/test/testProxyRoute.test.js
+++ b/test/testProxyRoute.test.js
@@ -18,8 +18,9 @@ import Proxy from '../src/proxy';
 const TEST_DEFAULT_REPO = {
   url: 'https://github.com/finos/git-proxy.git',
   name: 'git-proxy',
-  project: 'finos/gitproxy',
+  project: 'finos/git-proxy',
   host: 'github.com',
+  proxyUrlPrefix: '/github.com/finos/git-proxy.git',
 };
 
 const TEST_GITLAB_REPO = {
@@ -27,7 +28,16 @@ const TEST_GITLAB_REPO = {
   name: 'gitlab',
   project: 'gitlab-community/meta',
   host: 'gitlab.com',
-  proxyUrlPrefix: 'gitlab.com/gitlab-community/meta.git',
+  proxyUrlPrefix: '/gitlab.com/gitlab-community/meta.git',
+};
+
+const TEST_UNKNOWN_REPO = {
+  url: 'https://github.com/finos/fdc3.git',
+  name: 'fdc3',
+  project: 'finos/fdc3',
+  host: 'github.com',
+  proxyUrlPrefix: '/github.com/finos/fdc3.git',
+  fallbackUrlPrefix: '/finos/fdc3.git',
 };
 
 describe('proxy route filter middleware', () => {
@@ -42,6 +52,10 @@ describe('proxy route filter middleware', () => {
     sinon.restore();
   });
 
+  after(() => {
+    sinon.restore();
+  });
+
   it('should reject invalid git requests with 400', async () => {
     const res = await chai
       .request(app)
@@ -50,7 +64,7 @@ describe('proxy route filter middleware', () => {
       .set('accept', 'application/x-git-upload-pack-request');
 
     expect(res).to.have.status(400);
-    expect(res.text).to.equal('Invalid request received');
+    expect(res.text).to.contain('Invalid request received');
   });
 
   it('should handle blocked requests and return custom packet message', async () => {
@@ -68,7 +82,7 @@ describe('proxy route filter middleware', () => {
       .send(Buffer.from('0000'))
       .buffer();
 
-    expect(res.status).to.equal(200);
+    expect(res.status).to.equal(403);
     expect(res.text).to.contain('You shall not push!');
     expect(res.headers['content-type']).to.include('application/x-git-receive-pack-result');
     expect(res.headers['x-frame-options']).to.equal('DENY');
@@ -321,13 +335,6 @@ describe('proxy express application', async () => {
   };
 
   before(async () => {
-    // pass through requests
-    sinon.stub(chain, 'executeChain').resolves({
-      blocked: false,
-      blockedMessage: '',
-      error: false,
-    });
-
     // start the API and proxy
     proxy = new Proxy();
     apiApp = await service.start(proxy);
@@ -364,7 +371,7 @@ describe('proxy express application', async () => {
     // proxy a fetch request
     const res = await chai
       .request(proxy.getExpressApp())
-      .get('/github.com/finos/git-proxy.git/info/refs?service=git-upload-pack')
+      .get(`${TEST_DEFAULT_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
       .set('user-agent', 'git/2.42.0')
       .set('accept', 'application/x-git-upload-pack-request')
       .buffer();
@@ -373,11 +380,11 @@ describe('proxy express application', async () => {
     expect(res.text).to.contain('git-upload-pack');
   });
 
-  it('should proxy requests for the default GitHub repository using the backwards compatibility URL', async function () {
+  it('should proxy requests for the default GitHub repository using the fallback URL', async function () {
     // proxy a fetch request using a fallback URL
     const res = await chai
       .request(proxy.getExpressApp())
-      .get('/finos/git-proxy.git/info/refs?service=git-upload-pack')
+      .get(`${TEST_DEFAULT_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
       .set('user-agent', 'git/2.42.0')
       .set('accept', 'application/x-git-upload-pack-request')
       .buffer();
@@ -415,7 +422,7 @@ describe('proxy express application', async () => {
     // proxy a request to the new repo
     const res2 = await chai
       .request(proxy.getExpressApp())
-      .get(`/${TEST_GITLAB_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
+      .get(`${TEST_GITLAB_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
       .set('user-agent', 'git/2.42.0')
       .set('accept', 'application/x-git-upload-pack-request')
       .buffer();
@@ -442,11 +449,11 @@ describe('proxy express application', async () => {
     res.should.have.status(200);
 
     // confirm that its gone from the DB
-    repo = await db.getRepoByUrl(
-      TEST_GITLAB_REPO.url,
+    repo = await db.getRepoByUrl(TEST_GITLAB_REPO.url);
+    expect(
+      repo,
       'The GitLab repo still existed in the database after it should have been deleted...',
-    );
-    expect(repo).to.be.null;
+    ).to.be.null;
 
     // give the proxy half a second to restart
     await new Promise((resolve) => setTimeout(resolve, 500));
@@ -454,11 +461,41 @@ describe('proxy express application', async () => {
     // try (and fail) to proxy a request to gitlab.com
     const res2 = await chai
       .request(proxy.getExpressApp())
-      .get(`/${TEST_GITLAB_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
+      .get(`${TEST_GITLAB_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
       .set('user-agent', 'git/2.42.0')
       .set('accept', 'application/x-git-upload-pack-request')
       .buffer();
 
-    res2.should.have.status(404);
+    res2.should.have.status(403);
+  }).timeout(5000);
+
+  it('should not proxy requests for an unknown project', async function () {
+    // We are testing that the proxy stops proxying requests for a particular origin
+    // The chain is stubbed and will always passthrough requests, hence, we are only checking what hosts are proxied.
+
+    // the gitlab test repo should already exist
+    const repo = await db.getRepoByUrl(TEST_UNKNOWN_REPO.url);
+    expect(
+      repo,
+      'The unknown (but real) repo existed in the database which is not expected for this test',
+    ).to.be.null;
+
+    // try (and fail) to proxy a request to the repo directly
+    const res = await chai
+      .request(proxy.getExpressApp())
+      .get(`${TEST_UNKNOWN_REPO.proxyUrlPrefix}/info/refs?service=git-upload-pack`)
+      .set('user-agent', 'git/2.42.0')
+      .set('accept', 'application/x-git-upload-pack-request')
+      .buffer();
+    res.should.have.status(403);
+
+    // try (and fail) to proxy a request to the repo via the fallback URL directly
+    const res2 = await chai
+      .request(proxy.getExpressApp())
+      .get(`${TEST_UNKNOWN_REPO.fallbackUrlPrefix}/info/refs?service=git-upload-pack`)
+      .set('user-agent', 'git/2.42.0')
+      .set('accept', 'application/x-git-upload-pack-request')
+      .buffer();
+    res2.should.have.status(403);
   }).timeout(5000);
 });


### PR DESCRIPTION
resolves #1163 by ensuring that requests are never forwarded on for unknown repositories:
- Resolves issues with tests that were allowing requests to be forwarded for unknown repos
  - Stops stubs from the chain tests leaking into other tests 
  - Removes stubbing from Proxy express application tests
  - Removes chain test that checks that no processors are run unless the action type is "push" or "pull"
  - Adds an integration test that checks if pull requests are forwarded to unknown repos
- Improves handling of errors when executing the chain, ensuring that errors always block pushes
- Changes the HTTP response code for blocked pushes to consistently use 403 instead of 200
- Creates a default action chain that ensures that CheckRepoInAuthList is run for all requests
