### PR TITLE
fix: render committer and author email links instead of estimated profile links

### DIFF
--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -15,6 +15,7 @@ export interface CommitData {
   commitTs?: number;
   message: string;
   committer: string;
+  committerEmail: string;
   tree?: string;
   parent?: string;
   author: string;

--- a/src/ui/utils.tsx
+++ b/src/ui/utils.tsx
@@ -1,8 +1,10 @@
 import axios from 'axios';
+import React from 'react';
 import {
   SCMRepositoryMetadata,
   GitHubRepositoryMetadata,
   GitLabRepositoryMetadata,
+  CommitData,
 } from '../types/models';
 import moment from 'moment';
 
@@ -38,7 +40,50 @@ export const getGitProvider = (url: string) => {
 };
 
 /**
+ * Renders a block of mailto: links for author user names and email addresses found in an array of commit data.
+ *
+ * @param {CommitData[]} commitData The user.name to render in the link.
+ * @return {JSX.Element} A JSX Element representing the rendered links
+ */
+export const generateAuthorLinks = (commitData: CommitData[]) => {
+  const orderedAuthors: JSX.Element[] = [];
+  const uniqueAuthors: Set<string> = new Set();
+  commitData.forEach((row) => {
+    if (!uniqueAuthors.has(row.authorEmail)) {
+      uniqueAuthors.add(row.authorEmail);
+      orderedAuthors.push(
+        <div>
+          <a href={`mailto:${row.authorEmail}`}>
+            &quot;{row.author}&quot; &lt;{row.authorEmail}&gt;
+          </a>
+        </div>,
+      );
+    }
+  });
+  return <div>{orderedAuthors}</div>;
+};
+
+/**
+ * Renders a mailto: link for user name and email address, for use in rendering details of pushes.
+ *
+ * @param {string} name The user.name to render in the link.
+ * @param {string} email The email address to render in the link.
+ * @return {JSX.Element} An <a> tag based on the username and email address.
+ */
+export const generateEmailLink = (name: string, email: string) => {
+  return email ? (
+    <a href={`mailto:${email}`}>
+      &quot;{name}&quot; &lt;{email}&gt;
+    </a>
+  ) : (
+    <strong>No data...</strong>
+  );
+};
+
+/**
  * Predicts a user's profile URL based on their username and the SCM provider's details.
+ * TODO: update this to attempt to resolve a user email to a profile URL
+ *
  * @param {string} username The username.
  * @param {string} provider The name of the SCM provider.
  * @param {string} hostname The hostname of the SCM provider.
@@ -56,6 +101,9 @@ export const getUserProfileUrl = (username: string, provider: string, hostname: 
 
 /**
  * Attempts to construct a link to the user's profile at an SCM provider.
+ *
+ * TODO: update this to attempt to resolve a user email to a profile URL
+ *
  * @param {string} username The username.
  * @param {string} provider The name of the SCM provider.
  * @param {string} hostname The hostname of the SCM provider.

--- a/src/ui/views/OpenPushRequests/components/PushesTable.tsx
+++ b/src/ui/views/OpenPushRequests/components/PushesTable.tsx
@@ -17,7 +17,7 @@ import Search from '../../../components/Search/Search';
 import Pagination from '../../../components/Pagination/Pagination';
 import { PushData } from '../../../../types/models';
 import { trimPrefixRefsHeads, trimTrailingDotGit } from '../../../../db/helper';
-import { getGitProvider, getUserProfileLink } from '../../../utils';
+import { generateAuthorLinks, generateEmailLink } from '../../../utils';
 
 interface PushesTableProps {
   [key: string]: any;
@@ -91,8 +91,7 @@ const PushesTable: React.FC<PushesTableProps> = (props) => {
               <TableCell align='left'>Branch</TableCell>
               <TableCell align='left'>Commit SHA</TableCell>
               <TableCell align='left'>Committer</TableCell>
-              <TableCell align='left'>Author</TableCell>
-              <TableCell align='left'>Author E-mail</TableCell>
+              <TableCell align='left'>Authors</TableCell>
               <TableCell align='left'>Commit Message</TableCell>
               <TableCell align='left'>No. of Commits</TableCell>
               <TableCell align='right'></TableCell>
@@ -104,8 +103,9 @@ const PushesTable: React.FC<PushesTableProps> = (props) => {
               const repoBranch = trimPrefixRefsHeads(row.branch);
               const repoUrl = row.url;
               const repoWebUrl = trimTrailingDotGit(repoUrl);
-              const gitProvider = getGitProvider(repoUrl);
-              const hostname = new URL(repoUrl).hostname;
+              // may be used to resolve users to profile links in future
+              // const gitProvider = getGitProvider(repoUrl);
+              // const hostname = new URL(repoUrl).hostname;
               const commitTimestamp =
                 row.commitData[0]?.commitTs || row.commitData[0]?.commitTimestamp;
 
@@ -134,19 +134,19 @@ const PushesTable: React.FC<PushesTableProps> = (props) => {
                     </a>
                   </TableCell>
                   <TableCell align='left'>
-                    {getUserProfileLink(row.commitData[0].committer, gitProvider, hostname)}
-                  </TableCell>
-                  <TableCell align='left'>
-                    {getUserProfileLink(row.commitData[0].author, gitProvider, hostname)}
-                  </TableCell>
-                  <TableCell align='left'>
-                    {row.commitData[0]?.authorEmail ? (
-                      <a href={`mailto:${row.commitData[0].authorEmail}`}>
-                        {row.commitData[0].authorEmail}
-                      </a>
-                    ) : (
-                      'No data...'
+                    {/* render github/gitlab profile links in future 
+                    {getUserProfileLink(row.commitData[0].committerEmail, gitProvider, hostname)} 
+                    */}
+                    {generateEmailLink(
+                      row.commitData[0].committer,
+                      row.commitData[0]?.committerEmail,
                     )}
+                  </TableCell>
+                  <TableCell align='left'>
+                    {/* render github/gitlab profile links in future 
+                    {getUserProfileLink(row.commitData[0].authorEmail, gitProvider, hostname)} 
+                    */}
+                    {generateAuthorLinks(row.commitData)}
                   </TableCell>
                   <TableCell align='left'>{row.commitData[0]?.message || 'N/A'}</TableCell>
                   <TableCell align='left'>{row.commitData.length}</TableCell>

--- a/src/ui/views/PushDetails/PushDetails.tsx
+++ b/src/ui/views/PushDetails/PushDetails.tsx
@@ -24,7 +24,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 import Tooltip from '@material-ui/core/Tooltip';
 import { PushData } from '../../../types/models';
 import { trimPrefixRefsHeads, trimTrailingDotGit } from '../../../db/helper';
-import { getGitProvider } from '../../utils';
+import { generateEmailLink, getGitProvider } from '../../utils';
 
 const Dashboard: React.FC = () => {
   const { id } = useParams<{ id: string }>();
@@ -304,7 +304,6 @@ const Dashboard: React.FC = () => {
                     <TableCell>Timestamp</TableCell>
                     <TableCell>Committer</TableCell>
                     <TableCell>Author</TableCell>
-                    <TableCell>Author E-mail</TableCell>
                     <TableCell>Message</TableCell>
                   </TableRow>
                 </TableHead>
@@ -314,37 +313,8 @@ const Dashboard: React.FC = () => {
                       <TableCell>
                         {moment.unix(c.commitTs || c.commitTimestamp || 0).toString()}
                       </TableCell>
-                      <TableCell>
-                        {isGitHub && (
-                          <a
-                            href={`https://github.com/${c.committer}`}
-                            rel='noreferrer'
-                            target='_blank'
-                          >
-                            {c.committer}
-                          </a>
-                        )}
-                        {!isGitHub && <span>{c.committer}</span>}
-                      </TableCell>
-                      <TableCell>
-                        {isGitHub && (
-                          <a
-                            href={`https://github.com/${c.author}`}
-                            rel='noreferrer'
-                            target='_blank'
-                          >
-                            {c.author}
-                          </a>
-                        )}
-                        {!isGitHub && <span>{c.author}</span>}
-                      </TableCell>
-                      <TableCell>
-                        {c.authorEmail ? (
-                          <a href={`mailto:${c.authorEmail}`}>{c.authorEmail}</a>
-                        ) : (
-                          'No data...'
-                        )}
-                      </TableCell>
+                      <TableCell>{generateEmailLink(c.committer, c.committerEmail)}</TableCell>
+                      <TableCell>{generateEmailLink(c.author, c.authorEmail)}</TableCell>
                       <TableCell>{c.message}</TableCell>
                     </TableRow>
                   ))}


### PR DESCRIPTION
resolves #1175 

Replaces estimated links to git profile URLs on the OpenPushRequests and PushDetails views with mailto: links based on the email addresses used in commits (simple and will be supportable for all SCM providers/bare git servers).

OpenPushRequests was previously only rendering a link for the first author in a push. It will now extract a list of unique authors appearing in the push and render a link for each (one per line, in order of appearance). 

<img width="1468" height="505" alt="image" src="https://github.com/user-attachments/assets/50601bdc-e3d8-4891-bcb3-498c1768bb20" />

<img width="1499" height="698" alt="image" src="https://github.com/user-attachments/assets/4ae0d9bc-6e16-4232-9c0a-fccd776fd006" />

