### PR TITLE
feat: improve login page flexibility

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -40,18 +40,4 @@ describe('Login page', () => {
       .should('be.visible')
       .and('contain', 'You entered an invalid username or password...');
   });
-
-  describe('OIDC login button', () => {
-    it('should exist', () => {
-      cy.get('[data-test="oidc-login"]').should('exist');
-    });
-
-    // Validates that OIDC is configured correctly
-    it('should redirect to /oidc', () => {
-      // Set intercept first, since redirect on click can be quick
-      cy.intercept('GET', '/api/auth/oidc').as('oidcRedirect');
-      cy.get('[data-test="oidc-login"]').click();
-      cy.wait('@oidcRedirect');
-    });
-  });
 });

--- a/src/service/routes/auth.js
+++ b/src/service/routes/auth.js
@@ -66,6 +66,13 @@ const loginSuccessHandler = () => async (req, res) => {
   }
 };
 
+router.get('/config', (req, res) => {
+  res.send({
+    allLoginMethods: getAuthMethods().map((am) => am.type.toLowerCase()),
+    usernamePasswordMethod: getLoginStrategy(),
+  });
+});
+
 // TODO: provide separate auth endpoints for each auth strategy or chain compatibile auth strategies
 // TODO: if providing separate auth methods, inform the frontend so it has relevant UI elements and appropriate client-side behavior
 router.post(
@@ -82,9 +89,9 @@ router.post(
   loginSuccessHandler(),
 );
 
-router.get('/oidc', passport.authenticate(authStrategies['openidconnect'].type));
+router.get('/openidconnect', passport.authenticate(authStrategies['openidconnect'].type));
 
-router.get('/oidc/callback', (req, res, next) => {
+router.get('/openidconnect/callback', (req, res, next) => {
   passport.authenticate(authStrategies['openidconnect'].type, (err, user, info) => {
     if (err) {
       console.error('Authentication error:', err);

--- a/src/ui/services/auth.js
+++ b/src/ui/services/auth.js
@@ -32,7 +32,7 @@ export const getAxiosConfig = () => {
   return {
     withCredentials: true,
     headers: {
-      'X-CSRF-TOKEN': getCookie('csrf'),
+      'X-CSRF-TOKEN': getCookie('csrf') || '',
       Authorization: jwtToken ? `Bearer ${jwtToken}` : undefined,
     },
   };
@@ -43,9 +43,9 @@ export const getAxiosConfig = () => {
  * @param {Object} error - The error object
  * @return {string} The error message
  */
-export const processAuthError = (error) => {
+export const processAuthError = (error, jwtAuthEnabled = false) => {
   let errorMessage = `Failed to authorize user: ${error.response.data.trim()}. `;
-  if (!localStorage.getItem('ui_jwt_token')) {
+  if (jwtAuthEnabled && !localStorage.getItem('ui_jwt_token')) {
     errorMessage +=
       'Set your JWT token in the settings page or disable JWT auth in your app configuration.';
   } else {

--- a/src/ui/views/Login/Login.tsx
+++ b/src/ui/views/Login/Login.tsx
@@ -1,4 +1,4 @@
-import React, { useState, FormEvent } from 'react';
+import React, { useState, FormEvent, useEffect } from 'react';
 import { useNavigate, Navigate } from 'react-router-dom';
 import FormControl from '@material-ui/core/FormControl';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -12,10 +12,10 @@ import CardBody from '../../components/Card/CardBody';
 import CardFooter from '../../components/Card/CardFooter';
 import axios, { AxiosError } from 'axios';
 import logo from '../../assets/img/git-proxy.png';
-import { Badge, CircularProgress, Snackbar } from '@material-ui/core';
-import { getCookie } from '../../utils';
+import { Badge, CircularProgress, FormLabel, Snackbar } from '@material-ui/core';
 import { useAuth } from '../../auth/AuthProvider';
 import { API_BASE } from '../../apiBase';
+import { getAxiosConfig, processAuthError } from '../../services/auth';
 
 interface LoginResponse {
   username: string;
@@ -34,6 +34,19 @@ const Login: React.FC = () => {
   const [success, setSuccess] = useState<boolean>(false);
   const [gitAccountError, setGitAccountError] = useState<boolean>(false);
   const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [authMethods, setAuthMethods] = useState<string[]>([]);
+  const [usernamePasswordMethod, setUsernamePasswordMethod] = useState<string>('');
+
+  useEffect(() => {
+    axios.get(`${API_BASE}/api/auth/config`).then((response) => {
+      const authMethods = response.data.allLoginMethods;
+      const usernamePasswordMethod = response.data.usernamePasswordMethod;
+      const nonUsernamePasswordMethods = authMethods.filter((am) => am !== usernamePasswordMethod);
+
+      setAuthMethods(nonUsernamePasswordMethods);
+      setUsernamePasswordMethod(usernamePasswordMethod);
+    });
+  }, []);
 
   function validateForm(): boolean {
     return (
@@ -41,8 +54,8 @@ const Login: React.FC = () => {
     );
   }
 
-  function handleOIDCLogin(): void {
-    window.location.href = `${API_BASE}/api/auth/oidc`;
+  function handleAuthMethodLogin(authMethod: string): void {
+    window.location.href = `${API_BASE}/api/auth/${authMethod}`;
   }
 
   function handleSubmit(event: FormEvent): void {
@@ -50,17 +63,7 @@ const Login: React.FC = () => {
     setIsLoading(true);
 
     axios
-      .post<LoginResponse>(
-        loginUrl,
-        { username, password },
-        {
-          withCredentials: true,
-          headers: {
-            'Content-Type': 'application/json',
-            'X-CSRF-TOKEN': getCookie('csrf') || '',
-          },
-        },
-      )
+      .post<LoginResponse>(loginUrl, { username, password }, getAxiosConfig())
       .then(() => {
         window.sessionStorage.setItem('git.proxy.login', 'success');
         setMessage('Success!');
@@ -72,7 +75,7 @@ const Login: React.FC = () => {
           window.sessionStorage.setItem('git.proxy.login', 'success');
           setGitAccountError(true);
         } else if (error.response?.status === 403) {
-          setMessage('You do not have the correct access permissions...');
+          setMessage(processAuthError(error, false));
         } else {
           setMessage('You entered an invalid username or password...');
         }
@@ -116,6 +119,11 @@ const Login: React.FC = () => {
             <CardBody>
               <GridContainer>
                 <GridItem xs={12} sm={12} md={12}>
+                  <FormLabel component='legend' style={{ fontSize: '1.2rem', marginTop: 10 }}>
+                    {usernamePasswordMethod.charAt(0).toUpperCase() +
+                      usernamePasswordMethod.slice(1)}{' '}
+                    Authentication
+                  </FormLabel>
                   <FormControl fullWidth>
                     <InputLabel htmlFor='username'>Username</InputLabel>
                     <Input
@@ -156,9 +164,17 @@ const Login: React.FC = () => {
                   >
                     Login
                   </Button>
-                  <Button color='warning' block onClick={handleOIDCLogin} data-test='oidc-login'>
-                    Login with OIDC
-                  </Button>
+                  {authMethods.map((am) => (
+                    <Button
+                      color='warning'
+                      block
+                      onClick={() => handleAuthMethodLogin(am)}
+                      data-test={`${am}-login`}
+                      key={am}
+                    >
+                      Login with {am.toUpperCase()}
+                    </Button>
+                  ))}
                 </>
               ) : (
                 <div style={{ textAlign: 'center', width: '100%', opacity: 0.5, color: 'green' }}>
@@ -168,7 +184,12 @@ const Login: React.FC = () => {
             </CardFooter>
           </Card>
           <div style={{ textAlign: 'center', opacity: 0.9, fontSize: 12, marginTop: 20 }}>
-            <Badge overlap='rectangular' color='error' badgeContent='NEW' />
+            <Badge
+              overlap='rectangular'
+              color='error'
+              badgeContent='NEW'
+              style={{ marginRight: 20 }}
+            />
             <span style={{ paddingLeft: 20 }}>
               View our <a href='/dashboard/push'>open source activity feed</a> or{' '}
               <a href='/dashboard/repo'>scroll through projects</a> we contribute to

--- a/src/ui/views/Login/Login.tsx
+++ b/src/ui/views/Login/Login.tsx
@@ -116,57 +116,72 @@ const Login: React.FC = () => {
                 />
               </div>
             </CardHeader>
-            <CardBody>
-              <GridContainer>
-                <GridItem xs={12} sm={12} md={12}>
-                  <FormLabel component='legend' style={{ fontSize: '1.2rem', marginTop: 10 }}>
-                    {usernamePasswordMethod.charAt(0).toUpperCase() +
-                      usernamePasswordMethod.slice(1)}{' '}
-                    Authentication
-                  </FormLabel>
-                  <FormControl fullWidth>
-                    <InputLabel htmlFor='username'>Username</InputLabel>
-                    <Input
-                      id='username'
-                      type='text'
-                      value={username}
-                      onChange={(e) => setUsername(e.target.value)}
-                      autoFocus
-                      data-test='username'
-                    />
-                  </FormControl>
-                </GridItem>
-              </GridContainer>
-              <GridContainer>
-                <GridItem xs={12} sm={12} md={12}>
-                  <FormControl fullWidth>
-                    <InputLabel htmlFor='password'>Password</InputLabel>
-                    <Input
-                      id='password'
-                      type='password'
-                      value={password}
-                      onChange={(e) => setPassword(e.target.value)}
-                      data-test='password'
-                    />
-                  </FormControl>
-                </GridItem>
-              </GridContainer>
-            </CardBody>
-            <CardFooter>
+            {usernamePasswordMethod ? (
+              <CardBody>
+                <GridContainer>
+                  <GridItem xs={12} sm={12} md={12}>
+                    <FormLabel component='legend' style={{ fontSize: '1.2rem', marginTop: 10 }}>
+                      {usernamePasswordMethod.charAt(0).toUpperCase() +
+                        usernamePasswordMethod.slice(1)}{' '}
+                      Authentication
+                    </FormLabel>
+                    <FormControl fullWidth>
+                      <InputLabel htmlFor='username'>Username</InputLabel>
+                      <Input
+                        id='username'
+                        type='text'
+                        value={username}
+                        onChange={(e) => setUsername(e.target.value)}
+                        autoFocus
+                        data-test='username'
+                      />
+                    </FormControl>
+                  </GridItem>
+                </GridContainer>
+                <GridContainer>
+                  <GridItem xs={12} sm={12} md={12}>
+                    <FormControl fullWidth>
+                      <InputLabel htmlFor='password'>Password</InputLabel>
+                      <Input
+                        id='password'
+                        type='password'
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        data-test='password'
+                      />
+                    </FormControl>
+                  </GridItem>
+                </GridContainer>
+              </CardBody>
+            ) : (
+              <CardBody>
+                <FormLabel
+                  component='legend'
+                  style={{ fontSize: '1rem', marginTop: 10, marginBottom: 0 }}
+                >
+                  No username/password authentication method is configured. Please contact an
+                  administrator to enable this feature.
+                </FormLabel>
+              </CardBody>
+            )}
+            {/* Show login buttons if available (one on top of the other) */}
+            <CardFooter style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
               {!isLoading ? (
                 <>
-                  <Button
-                    color='success'
-                    block
-                    disabled={!validateForm()}
-                    type='submit'
-                    data-test='login'
-                  >
-                    Login
-                  </Button>
+                  {usernamePasswordMethod && (
+                    <Button
+                      color='success'
+                      block
+                      disabled={!validateForm()}
+                      type='submit'
+                      data-test='login'
+                    >
+                      Login
+                    </Button>
+                  )}
                   {authMethods.map((am) => (
                     <Button
-                      color='warning'
+                      color='success'
                       block
                       onClick={() => handleAuthMethodLogin(am)}
                       data-test={`${am}-login`}


### PR DESCRIPTION
Fixes #1206.

This PR adds a `/api/auth/config` endpoint to fetch the enabled username/password method, as well as the enabled one-click methods such as OIDC. It also fixes the display for the available config types on the Login page, and improves error handling and visibility of auth methods.

### Screenshots

#### When both local* and a custom, non-username/password method

<img width="2782" height="1312" alt="image" src="https://github.com/user-attachments/assets/afef6fd8-74df-4d40-b4fc-0243a3edc60f" />

#### When only local* is enabled

<img width="2782" height="1312" alt="image" src="https://github.com/user-attachments/assets/d18790e8-39cb-4bc1-ab35-3be0d357e8a8" />

#### When only a custom, non-username/password method is enabled

<img width="2782" height="1312" alt="image" src="https://github.com/user-attachments/assets/0bd30910-c216-4830-b547-1f981b43c432" />

*Defaults to AD if enabled, see `/src/routes/auth` for more details