### PR TITLE
fix: "MongoServerError: The _id cannot be changed" when updating users

### DIFF
--- a/src/db/mongo/users.ts
+++ b/src/db/mongo/users.ts
@@ -1,4 +1,4 @@
-import { OptionalId, Document } from 'mongodb';
+import { OptionalId, Document, ObjectId } from 'mongodb';
 import { toClass } from '../helper';
 import { User } from '../types';
 import { connect } from './helper';
@@ -55,7 +55,9 @@ export const updateUser = async (user: User): Promise<void> => {
   if (user.email) {
     user.email = user.email.toLowerCase();
   }
+  const { _id, ...userWithoutId } = user;
+  const filter = _id ? { _id: new ObjectId(_id) } : { username: user.username };
   const options = { upsert: true };
   const collection = await connect(collectionName);
-  await collection.updateOne({ username: user.username }, { $set: user }, options);
+  await collection.updateOne(filter, { $set: userWithoutId }, options);
 };


### PR DESCRIPTION
# Summary

Updating a user (e.g., adding a GitHub username) currently fails with a MongoDB server exception. The issue arises because the user object already includes an _id, and the update attempt tries to overwrite it:

```
MongoServerError: The _id field cannot be changed
```

## Fix

* Removes the `_id` property from the user object before updating.
* Performs an update by `_id` if one exists.
* If no `_id` is present, inserts a new user with a no-op filter (`{ username: user.username }`).