### PR TITLE
chore: generate provenance statement when publishing to npm

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -4,6 +4,7 @@ on:
     types: [published]
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   build:
@@ -30,10 +31,10 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           if [[ "$VERSION" == *"-"* ]]; then
             echo "Publishing pre-release: $VERSION"
-            npm publish --access=public --tag rc
+            npm publish --provenance --access=public --tag rc
           else
             echo "Publishing stable release: $VERSION"
-            npm publish --access=public
+            npm publish --provenance --access=public
           fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
resolves #1241 

Adds the argument for NPM/GIthub to generate a provenance statement when publishing to NPM, as per instructions at: https://docs.npmjs.com/generating-provenance-statements