### PR TITLE
chore: add confirmation dialog

### DIFF
--- a/src/ui/views/RepoDetails/Components/DeleteRepoDialog.tsx
+++ b/src/ui/views/RepoDetails/Components/DeleteRepoDialog.tsx
@@ -12,7 +12,7 @@ interface ConfirmDeleteRepoProps {
   onConfirm: () => void;
 }
 
-const ConfirmDeleteRepo: React.FC<ConfirmDeleteRepoProps> = ({
+const DeleteRepoDialog: React.FC<ConfirmDeleteRepoProps> = ({
   repoName,
   open,
   onClose,
@@ -67,4 +67,4 @@ const ConfirmDeleteRepo: React.FC<ConfirmDeleteRepoProps> = ({
   );
 };
 
-export default ConfirmDeleteRepo;
+export default DeleteRepoDialog;

--- a/src/ui/views/RepoDetails/RepoDetails.tsx
+++ b/src/ui/views/RepoDetails/RepoDetails.tsx
@@ -23,7 +23,7 @@ import CodeActionButton from '../../components/CustomButtons/CodeActionButton';
 import { trimTrailingDotGit } from '../../../db/helper';
 import { fetchRemoteRepositoryData } from '../../utils';
 import { SCMRepositoryMetadata } from '../../../types/models';
-import ConfirmDeleteRepo from './Components/ConfirmDeleteRepo';
+import DeleteRepoDialog from './Components/DeleteRepoDialog';
 
 interface RepoData {
   _id: string;
@@ -269,7 +269,7 @@ const RepoDetails: React.FC = () => {
         </Card>
       </GridItem>
 
-      <ConfirmDeleteRepo
+      <DeleteRepoDialog
         repoName={data.name}
         open={confirmDeleteOpen}
         onClose={() => setConfirmDeleteOpen(false)}


### PR DESCRIPTION
# Summary

This PR adds a delete confirmation dialog to prevent accidental repository deletions.

## Background

I unintentionally deleted a repository after clicking “Delete” while moving the mouse toward the “Code” button. To avoid similar mistakes, this PR introduces a confirmation step before deletion.

## Fix

- Adds a confirmation dialog when deleting a repository.
- Requires the user to type (or paste) the repository name to confirm the action.
- Follows the standard UI convention used for similar destructive actions.

<img height="405" alt="CleanShot 2025-10-31 at 14 54 38@2x" src="https://github.com/user-attachments/assets/ecd760d9-64e8-43d4-98a2-88563b446923" />

The delete button is enabled when the correct repo name has been added.

<img height="405" alt="CleanShot 2025-10-31 at 14 55 29@2x" src="https://github.com/user-attachments/assets/d15083f9-3510-4c93-ab64-0a45befc54dc" />

## Note

There’s a quirk where you can’t remove the default repository. Right after a repo is deleted, the handler restarts the proxy, and during that restart, proxyPreparations() runs again — which re-inserts every repo defined in `proxy.config.json`. If the repo you deleted is listed there, it’s immediately recreated, so the UI still shows it even after a refresh.