### PR TITLE
fix: remove unused fileDB params from config schema, defaults, and docs

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -420,12 +420,7 @@
           "description": "Connection properties for an neDB file-based database",
           "properties": {
             "type": { "type": "string", "const": "fs" },
-            "enabled": { "type": "boolean" },
-            "params": {
-              "type": "object",
-              "description": "Legacy config property not currently used",
-              "deprecated": true
-            }
+            "enabled": { "type": "boolean" }
           },
           "required": ["type", "enabled"]
         }

--- a/packages/git-proxy-cli/test/testCli.proxy.config.json
+++ b/packages/git-proxy-cli/test/testCli.proxy.config.json
@@ -13,9 +13,6 @@
   "sink": [
     {
       "type": "fs",
-      "params": {
-        "filepath": "./."
-      },
       "enabled": true
     },
     {

--- a/proxy.config.json
+++ b/proxy.config.json
@@ -19,9 +19,6 @@
   "sink": [
     {
       "type": "fs",
-      "params": {
-        "filepath": "./."
-      },
       "enabled": true
     },
     {

--- a/src/config/generated/config.ts
+++ b/src/config/generated/config.ts
@@ -496,10 +496,6 @@ export interface Database {
    */
   options?: Options;
   type: DatabaseType;
-  /**
-   * Legacy config property not currently used
-   */
-  params?: { [key: string]: any };
   [property: string]: any;
 }
 
@@ -938,7 +934,6 @@ const typeMap: any = {
       { json: 'enabled', js: 'enabled', typ: true },
       { json: 'options', js: 'options', typ: u(undefined, r('Options')) },
       { json: 'type', js: 'type', typ: r('DatabaseType') },
-      { json: 'params', js: 'params', typ: u(undefined, m('any')) },
     ],
     'any',
   ),

--- a/test-e2e.proxy.config.json
+++ b/test-e2e.proxy.config.json
@@ -24,9 +24,6 @@
   "sink": [
     {
       "type": "fs",
-      "params": {
-        "filepath": "./."
-      },
       "enabled": false
     },
     {

--- a/test/generated-config.test.ts
+++ b/test/generated-config.test.ts
@@ -96,9 +96,6 @@ describe('Generated Config (QuickType)', () => {
         sink: [
           {
             type: 'fs',
-            params: {
-              filepath: './.',
-            },
             enabled: true,
           },
         ],
@@ -149,7 +146,7 @@ describe('Generated Config (QuickType)', () => {
           { project: 'proj2', name: 'repo2', url: 'https://github.com/proj2/repo2.git' },
         ],
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
         plugins: ['plugin1', 'plugin2'],
         privateOrganizations: ['org1', 'org2'],
       };
@@ -167,7 +164,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://proxy.example.com',
         cookieSecret: 'secret',
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
         tls: {
           enabled: true,
           key: '/path/to/key.pem',
@@ -197,7 +194,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://proxy.example.com',
         cookieSecret: 'secret',
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
 
         api: {
           ls: {
@@ -236,7 +233,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://proxy.example.com',
         cookieSecret: 'secret',
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
 
         // Test different array structures
         authorisedList: [
@@ -267,7 +264,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://proxy.example.com',
         cookieSecret: 'secret',
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
 
         sessionMaxAgeHours: 0,
         csrfProtection: false,
@@ -313,7 +310,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://proxy.example.com',
         cookieSecret: null,
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
         contactEmail: null,
         urlShortener: null,
       };
@@ -328,7 +325,7 @@ describe('Generated Config (QuickType)', () => {
         proxyUrl: 'https://test.com',
         cookieSecret: 'secret',
         authentication: [{ type: 'local', enabled: true }],
-        sink: [{ type: 'fs', params: { filepath: './.' }, enabled: true }],
+        sink: [{ type: 'fs', enabled: true }],
         rateLimit: {
           windowMs: 60000,
           limit: 150,

--- a/website/docs/configuration/reference.mdx
+++ b/website/docs/configuration/reference.mdx
@@ -1192,23 +1192,6 @@ Specific value: `"fs"`
 </blockquote>
 </details>
 
-<details>
-<summary>
-<strong> <a name="sink_items_oneOf_i1_params"></a>15.1.2.3. [Optional] Property GitProxy configuration file > sink > sink items > oneOf > item 1 > params</strong>
-</summary>
-<blockquote>
-
-|                           |                  |
-| ------------------------- | ---------------- |
-| **Type**                  | `object`         |
-| **Required**              | No               |
-| **Additional properties** | Any type allowed |
-
-**Description:** Legacy config property not currently used
-
-</blockquote>
-</details>
-
 </blockquote>
 
 </blockquote>
@@ -2046,4 +2029,4 @@ Specific value: `"jwt"`
 </details>
 
 ----------------------------------------------------------------------------------------------------------------------------
-Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2025-12-12 at 12:07:48 +0000
+Generated using [json-schema-for-humans](https://github.com/coveooss/json-schema-for-humans) on 2026-01-21 at 14:25:25 +0100


### PR DESCRIPTION
## Summary

Removes the unused `params` configuration property from the fileDB (`fs` type) database sink configuration, as identified in #1288.

The `params.filepath` property was defined in the configuration schema and default config but was never actually read by the fileDB implementation. The database files are created at hardcoded paths (`./.data` and `./.data/db`) regardless of what was configured.

## Changes

- Removed `params` property from the File-based DB Config schema in `config.schema.json`
- Removed `params` block from default config in `proxy.config.json`
- Updated test configuration files to remove unused `params`
- Regenerated TypeScript config types
- Updated test cases that referenced the `params` property

## Test plan

- [x] All existing tests pass (539 tests)
- [x] Generated TypeScript types no longer include `params` field
- [x] Config validation still works correctly for `fs` type sinks

Closes #1288