### PR TITLE
fix: use CompletedAttestation.answers in AttestationView

### DIFF
--- a/src/ui/views/PushDetails/components/AttestationInfo.tsx
+++ b/src/ui/views/PushDetails/components/AttestationInfo.tsx
@@ -20,7 +20,8 @@ import { CheckCircle } from '@material-ui/icons';
 import Tooltip from '@material-ui/core/Tooltip';
 import UserLink from '../../../components/UserLink/UserLink';
 import AttestationView from './AttestationView';
-import { AttestationFormData, PushActionView } from '../../../types';
+import { PushActionView } from '../../../types';
+import { CompletedAttestation } from '../../../../proxy/processors/types';
 
 interface AttestationInfoProps {
   push: PushActionView;
@@ -109,7 +110,7 @@ const AttestationInfo: React.FC<AttestationInfoProps> = ({
 
       {!push.autoApproved && (
         <AttestationView
-          data={push.attestation as AttestationFormData}
+          data={push.attestation as CompletedAttestation}
           attestation={attestation}
           setAttestation={setAttestation}
         />

--- a/src/ui/views/PushDetails/components/AttestationView.tsx
+++ b/src/ui/views/PushDetails/components/AttestationView.tsx
@@ -28,12 +28,12 @@ import { withStyles } from '@material-ui/core/styles';
 import { green } from '@material-ui/core/colors';
 import { setURLShortenerData } from '../../../services/config';
 import UserLink from '../../../components/UserLink/UserLink';
-import { AttestationFormData } from '../../../types';
+import { CompletedAttestation } from '../../../../proxy/processors/types';
 
 export interface AttestationViewProps {
   attestation: boolean;
   setAttestation: (value: boolean) => void;
-  data: AttestationFormData;
+  data: CompletedAttestation;
 }
 
 const StyledFormControlLabel = withStyles({
@@ -120,7 +120,7 @@ const AttestationView: React.FC<AttestationViewProps> = ({ attestation, setAttes
           style={{ margin: '0px 15px 0px 35px', rowGap: '20px', padding: '20px' }}
           row={false}
         >
-          {data.questions.map((question, index) => (
+          {data.answers.map((question, index) => (
             <div key={index}>
               <StyledFormControlLabel
                 control={<GreenCheckbox checked={question.checked} />}


### PR DESCRIPTION

`questions` have been renamed to `answers` on the server side, introducing `CompletedAttestation` with `answers: AttestationAnswer[]`. However, `AttestationView` was still reading `data.questions`, which is `undefined` on the stored object, causing a `TypeError` at render time.

The error was silently caught by the `ErrorBoundary` hiding the crash and causing the `[data-testid="push-status"]` element to disappear — which is why the Cypress e2e test added in PR #1403 was failing only for the Approve flow (Reject and Cancel don't store attestation data, so `AttestationInfo` returns `null` for those states).