### PR TITLE
chore: bump git-proxy version to `2.0.0-rc.5`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@finos/git-proxy",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0-rc.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@finos/git-proxy",
-      "version": "2.0.0-rc.4",
+      "version": "2.0.0-rc.5",
       "license": "Apache-2.0",
       "workspaces": [
         "./packages/git-proxy-cli"
@@ -14797,10 +14797,10 @@
     },
     "packages/git-proxy-cli": {
       "name": "@finos/git-proxy-cli",
-      "version": "2.0.0-rc.4",
+      "version": "2.0.0-rc.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@finos/git-proxy": "2.0.0-rc.4",
+        "@finos/git-proxy": "2.0.0-rc.5",
         "axios": "^1.13.6",
         "yargs": "^17.7.2"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0-rc.5",
   "description": "Deploy custom push protections and policies on top of Git.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/git-proxy-cli/package.json
+++ b/packages/git-proxy-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@finos/git-proxy-cli",
-  "version": "2.0.0-rc.4",
+  "version": "2.0.0-rc.5",
   "description": "Command line interface tool for FINOS GitProxy.",
   "bin": {
     "git-proxy-cli": "./dist/index.js"
@@ -8,7 +8,7 @@
   "dependencies": {
     "axios": "^1.13.6",
     "yargs": "^17.7.2",
-    "@finos/git-proxy": "2.0.0-rc.4"
+    "@finos/git-proxy": "2.0.0-rc.5"
   },
   "scripts": {
     "build": "tsc",

--- a/plugins/git-proxy-plugin-samples/package.json
+++ b/plugins/git-proxy-plugin-samples/package.json
@@ -16,6 +16,6 @@
     "express": "^5.2.1"
   },
   "peerDependencies": {
-    "@finos/git-proxy": "^1.19.2"
+    "@finos/git-proxy": "^2.0.0-rc.5"
   }
 }


### PR DESCRIPTION
PR for bumping to `rc.5`, and hopefully the last one before v2!

The v2 checklist is finally complete: #1368

We can spend the following week testing, and if everything goes well we can do the v2 release before/during our next community call #1454