### PR TITLE
fix: restore broken CLI package

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,11 @@
       "types": "./dist/src/ui/index.d.ts",
       "import": "./dist/src/ui/index.js",
       "require": "./dist/src/ui/index.js"
+    },
+    "./utils/errors": {
+      "types": "./dist/src/utils/errors.d.ts",
+      "import": "./dist/src/utils/errors.js",
+      "require": "./dist/src/utils/errors.js"
     }
   },
   "scripts": {

--- a/packages/git-proxy-cli/index.ts
+++ b/packages/git-proxy-cli/index.ts
@@ -229,12 +229,19 @@ async function authoriseGitPush(id: string) {
     if (isAxiosError(error) && error.response) {
       switch (error.response.status) {
         case 401:
+        case 403:
           console.error('Error: Authorise: Authentication required');
           process.exitCode = 3;
           break;
         case 404:
           console.error(`Error: Authorise: ID: '${id}': Not Found`);
           process.exitCode = 4;
+          break;
+        default:
+          console.error(
+            `Error: Authorise: '${error.response.status}': ${error.response.data?.message || error.message}`,
+          );
+          process.exitCode = 5;
       }
     } else {
       handleErrorAndLog(error, `Error: Authorise: '${id}'`);
@@ -247,7 +254,7 @@ async function authoriseGitPush(id: string) {
  * Reject git push by ID
  * @param {string} id The ID of the git push to reject
  */
-async function rejectGitPush(id: string) {
+async function rejectGitPush(id: string, reason: string) {
   if (!fs.existsSync(GIT_PROXY_COOKIE_FILE)) {
     console.error('Error: Reject: Authentication required');
     process.exitCode = 1;
@@ -263,7 +270,7 @@ async function rejectGitPush(id: string) {
 
     await axios.post(
       `${baseUrl}/api/v1/push/${id}/reject`,
-      {},
+      { reason },
       {
         headers: { Cookie: cookies },
       },
@@ -274,12 +281,19 @@ async function rejectGitPush(id: string) {
     if (isAxiosError(error) && error.response) {
       switch (error.response.status) {
         case 401:
+        case 403:
           console.error('Error: Reject: Authentication required');
           process.exitCode = 3;
           break;
         case 404:
           console.error(`Error: Reject: ID: '${id}': Not Found`);
           process.exitCode = 4;
+          break;
+        default:
+          console.error(
+            `Error: Reject: '${error.response.status}': ${error.response.data?.message || error.message}`,
+          );
+          process.exitCode = 5;
       }
     } else {
       handleErrorAndLog(error, `Error: Reject: '${id}'`);
@@ -319,12 +333,19 @@ async function cancelGitPush(id: string) {
     if (isAxiosError(error) && error.response) {
       switch (error.response.status) {
         case 401:
+        case 403:
           console.error('Error: Cancel: Authentication required');
           process.exitCode = 3;
           break;
         case 404:
           console.error(`Error: Cancel: ID: '${id}': Not Found`);
           process.exitCode = 4;
+          break;
+        default:
+          console.error(
+            `Error: Cancel: '${error.response.status}': ${error.response.data?.message || error.message}`,
+          );
+          process.exitCode = 5;
       }
     } else {
       handleErrorAndLog(error, `Error: Cancel: '${id}'`);
@@ -423,6 +444,7 @@ async function createUser(
     if (isAxiosError(error) && error.response) {
       switch (error.response.status) {
         case 401:
+        case 403:
           console.error('Error: Create User: Authentication required');
           process.exitCode = 3;
           break;
@@ -563,9 +585,14 @@ yargs(hideBin(process.argv)) // eslint-disable-line @typescript-eslint/no-unused
         demandOption: true,
         type: 'string',
       },
+      reason: {
+        describe: 'Reason for rejection',
+        type: 'string',
+        default: 'Rejected via GitProxy CLI',
+      },
     },
     handler(argv) {
-      rejectGitPush(argv.id);
+      rejectGitPush(argv.id, argv.reason);
     },
   })
   .command({

--- a/packages/git-proxy-cli/test/testCli.proxy.config.json
+++ b/packages/git-proxy-cli/test/testCli.proxy.config.json
@@ -24,6 +24,14 @@
       "enabled": false
     }
   ],
+  "attestationConfig": {
+    "questions": [
+      {
+        "label": "Authorising via GitProxy CLI",
+        "required": true
+      }
+    ]
+  },
   "authentication": [
     {
       "type": "local",

--- a/packages/git-proxy-cli/test/testCli.test.ts
+++ b/packages/git-proxy-cli/test/testCli.test.ts
@@ -19,10 +19,14 @@ import path from 'path';
 import { describe, it, beforeAll, afterAll } from 'vitest';
 
 import { setConfigFile } from '../../../src/config/file';
+import { invalidateCache } from '../../../src/config';
 import { SAMPLE_REPO } from '../../../src/proxy/processors/constants';
 import { handleErrorAndLog } from '../../../src/utils/errors';
 
-setConfigFile(path.join(process.cwd(), 'test', 'testCli.proxy.config.json'));
+setConfigFile(
+  path.join(process.cwd(), 'packages', 'git-proxy-cli', 'test', 'testCli.proxy.config.json'),
+);
+invalidateCache();
 
 /* test constants */
 // push ID which does not exist
@@ -774,7 +778,7 @@ describe('test git-proxy-cli', function () {
         let expectedErrorMessages = null;
         await helper.runCli(cli, expectedExitCode, expectedMessages, expectedErrorMessages);
 
-        cli = `${CLI_PATH} reject --id ${pushId}`;
+        cli = `${CLI_PATH} reject --id ${pushId} --reason "Rejected via CLI test"`;
         expectedExitCode = 0;
         expectedMessages = [`Reject: ID: '${pushId}': OK`];
         expectedErrorMessages = null;

--- a/packages/git-proxy-cli/test/testCliUtils.ts
+++ b/packages/git-proxy-cli/test/testCliUtils.ts
@@ -20,13 +20,13 @@ import { exec } from 'child_process';
 import { expect } from 'vitest';
 import { Request } from 'express';
 
-import Proxy from '../../../src/proxy';
+import { Proxy } from '../../../src/proxy';
 import { Action } from '../../../src/proxy/actions/Action';
 import { Step } from '../../../src/proxy/actions/Step';
-import { exec as execProcessor } from '../../../src/proxy/processors/push-action/audit';
+import { exec as execProcessor } from '../../../src/proxy/processors/post-processor/audit';
 import * as db from '../../../src/db';
 import { Repo } from '../../../src/db/types';
-import service from '../../../src/service';
+import { Service as service } from '../../../src/service';
 import { CommitData } from '../../../src/proxy/processors/types';
 
 const execAsync = util.promisify(exec);

--- a/packages/git-proxy-cli/tsconfig.json
+++ b/packages/git-proxy-cli/tsconfig.json
@@ -15,7 +15,8 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "outDir": "./dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "types": ["node"]
   },
   "include": ["index.ts", "types.ts"],
   "exclude": [


### PR DESCRIPTION
Fixes #1498                                                                                                                         
  - Fix TypeScript build configuration for the CLI workspace                                                                   
  - Update stale imports and missing package exports that drifted from the main codebase                                       
  - Align CLI error handling with current server API responses (403, 400, reject reason, attestation)                          
  - Fix test setup to load the correct configuration