### PR TITLE
ci: run test coverage on CLI package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Upload test coverage report
         uses: codecov/codecov-action@1af58845a975a7985b0beb0cbe6fbbb71a41dbad # v5.5.3
         with:
-          files: ./coverage/lcov.info
+          files: ./coverage/lcov.info,./coverage-cli/lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Build frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
       - name: Build TypeScript
         run: npm run build-ts
 
+      - name: Build CLI
+        run: |
+          npm run build -w @finos/git-proxy-cli
+          npm rebuild @finos/git-proxy-cli
+
       - name: Test
         id: test
         run: |
@@ -117,6 +122,11 @@ jobs:
 
       - name: Build TypeScript
         run: npm run build-ts
+
+      - name: Build CLI
+        run: |
+          npm run build -w @finos/git-proxy-cli
+          npm rebuild @finos/git-proxy-cli
 
       - name: Test
         id: test

--- a/.github/workflows/unused-dependencies.yml
+++ b/.github/workflows/unused-dependencies.yml
@@ -21,7 +21,7 @@ jobs:
           node-version: '24.x'
       - name: 'Run depcheck'
         run: |
-          npx depcheck --skip-missing --ignores="tsx,@babel/*,@commitlint/*,eslint,eslint-*,husky,ts-node,concurrently,nyc,prettier,typescript,tsconfig-paths,vite-tsconfig-paths,quicktype,history,@types/domutils,@vitest/coverage-v8,cross-env"
+          npx depcheck --skip-missing --ignores="tsx,@babel/*,@commitlint/*,eslint,eslint-*,husky,ts-node,concurrently,nyc,prettier,typescript,tsconfig-paths,vite-tsconfig-paths,quicktype,history,@types/domutils,@vitest/coverage-v8,cross-env,c8"
           echo $?
           if [[ $? == 1 ]]; then
             echo "Unused dependencies or devDependencies found"

--- a/.gitignore
+++ b/.gitignore
@@ -245,6 +245,7 @@ dist
 
 # testing
 /coverage
+/coverage-cli
 
 # production
 /build

--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "@types/yargs": "^17.0.35",
         "@vitejs/plugin-react": "^5.1.2",
         "@vitest/coverage-v8": "^3.2.4",
+        "c8": "^11.0.0",
         "cross-env": "^10.1.0",
         "cypress": "^15.9.0",
         "eslint": "^9.39.2",
@@ -4325,6 +4326,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "dev": true,
@@ -5892,6 +5900,139 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/c8": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/c8/-/c8-11.0.0.tgz",
+      "integrity": "sha512-e/uRViGHSVIJv7zsaDKM7VRn2390TgHXqUSvYwPHBQaU6L7E9L0n9JbdkwdYPvshDT0KymBmmlwSpms3yBaMNg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.1",
+        "@istanbuljs/schema": "^0.1.3",
+        "find-up": "^5.0.0",
+        "foreground-child": "^3.1.1",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.1.6",
+        "test-exclude": "^8.0.0",
+        "v8-to-istanbul": "^9.0.0",
+        "yargs": "^17.7.2",
+        "yargs-parser": "^21.1.1"
+      },
+      "bin": {
+        "c8": "bin/c8.js"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "peerDependencies": {
+        "monocart-coverage-reports": "^2"
+      },
+      "peerDependenciesMeta": {
+        "monocart-coverage-reports": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/c8/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/c8/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/c8/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/lru-cache": {
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.3.tgz",
+      "integrity": "sha512-JvNw9Y81y33E+BEYPr0U7omo+U9AySnsMsEiXgwT6yqd31VQWTLNQqmT4ou5eqPFUrTfIDFta2wKhB1hyohtAQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/c8/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/c8/node_modules/test-exclude": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-8.0.0.tgz",
+      "integrity": "sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^13.0.6",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/cac": {
@@ -10817,10 +10958,10 @@
       }
     },
     "node_modules/minipass": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-      "license": "ISC",
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
@@ -14135,6 +14276,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validator": {
       "version": "13.15.26",
       "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.26.tgz",
@@ -14824,6 +14980,15 @@
         "node": ">=12"
       }
     },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/yargs/node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT"
@@ -14838,13 +15003,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -167,6 +167,7 @@
     "@types/yargs": "^17.0.35",
     "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^3.2.4",
+    "c8": "^11.0.0",
     "cross-env": "^10.1.0",
     "cypress": "^15.9.0",
     "eslint": "^9.39.2",

--- a/packages/git-proxy-cli/package.json
+++ b/packages/git-proxy-cli/package.json
@@ -14,7 +14,7 @@
     "build": "tsc",
     "lint": "eslint \"./*.ts\" --fix",
     "test": "cd ../.. && vitest --run --dir packages/git-proxy-cli/test",
-    "test-coverage-ci": "cd ../.. && c8 --include 'packages/git-proxy-cli/dist/**' --exclude 'packages/git-proxy-cli/test/**' --reporter lcovonly --reporter text vitest --run --dir packages/git-proxy-cli/test"
+    "test-coverage-ci": "cd ../.. && c8 --reports-dir ./coverage-cli --include 'packages/git-proxy-cli/dist/**' --exclude 'packages/git-proxy-cli/test/**' --reporter lcovonly --reporter text vitest --run --dir packages/git-proxy-cli/test"
   },
   "author": "Miklos Sagi",
   "license": "Apache-2.0",

--- a/packages/git-proxy-cli/package.json
+++ b/packages/git-proxy-cli/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "tsc",
     "lint": "eslint \"./*.ts\" --fix",
-    "test": "cd ../.. && vitest --run --dir packages/git-proxy-cli/test"
+    "test": "cd ../.. && vitest --run --dir packages/git-proxy-cli/test",
+    "test-coverage-ci": "cd ../.. && c8 --include 'packages/git-proxy-cli/dist/**' --exclude 'packages/git-proxy-cli/test/**' --reporter lcovonly --reporter text vitest --run --dir packages/git-proxy-cli/test"
   },
   "author": "Miklos Sagi",
   "license": "Apache-2.0",

--- a/packages/git-proxy-cli/package.json
+++ b/packages/git-proxy-cli/package.json
@@ -14,7 +14,7 @@
     "build": "tsc",
     "lint": "eslint \"./*.ts\" --fix",
     "test": "cd ../.. && vitest --run --dir packages/git-proxy-cli/test",
-    "test-coverage-ci": "cd ../.. && c8 --reports-dir ./coverage-cli --include 'packages/git-proxy-cli/dist/**' --exclude 'packages/git-proxy-cli/test/**' --reporter lcovonly --reporter text vitest --run --dir packages/git-proxy-cli/test"
+    "test-coverage-ci": "cd ../.. && c8 --reports-dir ./coverage-cli --include \"packages/git-proxy-cli/dist/**\" --exclude \"packages/git-proxy-cli/test/**\" --reporter lcovonly --reporter text vitest --run --dir packages/git-proxy-cli/test --test-timeout 15000"
   },
   "author": "Miklos Sagi",
   "license": "Apache-2.0",

--- a/packages/git-proxy-cli/tsconfig.json
+++ b/packages/git-proxy-cli/tsconfig.json
@@ -14,6 +14,7 @@
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
+    "sourceMap": true,
     "outDir": "./dist",
     "rootDir": ".",
     "types": ["node"]


### PR DESCRIPTION
Fixes #1331.
This PR is based on #1499 and should be merged after it. 
  - Add c8 to capture test coverage from CLI subprocess executions                                                                                                                                                                                                                  
  - Add test-coverage-ci script to CLI workspace so --workspaces --if-present picks it up                                                                                                                                                                                             
  - Add CLI build step to CI workflow