### PR TITLE
chore: update build ignore rule in netlify.toml

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,2 @@
 [build]
-  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../website/"
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../website/ package.json"


### PR DESCRIPTION
resolves #1534

This PR updates the Netlify build ignore logic to ensure that documentation builds are triggered whenever package.json is modified.

Currently, the netlify.toml only watches for changes within the current directory (.) and the ../website/ directory. Because of this, version bumps or release candidate promotions that only modify package.json do not trigger a fresh docs deployment. This results in the homepage displaying stale version numbers.

By appending package.json to the monitored paths in the git diff command, Netlify will now correctly trigger a build when the version changes, even if no documentation content was modified.