### PR TITLE
feat: expose service module through package exports (#1539)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,11 @@
       "types": "./dist/src/utils/errors.d.ts",
       "import": "./dist/src/utils/errors.js",
       "require": "./dist/src/utils/errors.js"
+    },
+    "./service": {
+      "types": "./dist/src/service/index.d.ts",
+      "import": "./dist/src/service/index.js",
+      "require": "./dist/src/service/index.js"
     }
   },
   "scripts": {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,7 +27,6 @@ import { validateConfig } from './validators';
 import { handleErrorAndLog, handleErrorAndThrow } from '../utils/errors';
 
 export { setConfigFile, getConfigFile, validate } from './file';
-export { serverConfig } from './env';
 
 // Deprecated compatibility fields are still optional because the defaults do not set them.
 type OptionalTopLevelConfigKey = 'proxyUrl' | 'sslCertPemPath' | 'sslKeyPemPath';
@@ -225,6 +224,11 @@ export const getUpstreamProxyConfig = () => {
 export const getAuthorisedList = () => {
   const config = loadFullConfiguration();
   return config.authorisedList;
+};
+
+// Get GIT_PROXY_UI_PORT
+export const getUIPort = (): number => {
+  return Number(serverConfig.GIT_PROXY_UI_PORT);
 };
 
 // Gets a list of authorised repositories

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -22,8 +22,12 @@ import { ConfigLoader } from './ConfigLoader';
 import { Configuration } from './types';
 import { serverConfig } from './env';
 import { getConfigFile } from './file';
+
 import { validateConfig } from './validators';
 import { handleErrorAndLog, handleErrorAndThrow } from '../utils/errors';
+
+export { setConfigFile, getConfigFile, validate } from './file';
+export { serverConfig } from './env';
 
 // Cache for current configuration
 let _currentConfig: GitProxyConfig | null = null;


### PR DESCRIPTION
## Description

Exposes the service module through package exports and updates configuration exports to support service module accessibility.

General changes:

* Added package exports entry for the service module
* Updated `src/config/index.ts` to expose the required configuration exports
* Ensured service module accessibility through package-level exports
* Verified project build and TypeScript publish build complete successfully
* Validated linting, formatting, and type checks pass successfully

## Related Issue

Resolves #1539

## Checklist

### General

* [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
* [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
* [ ] I have a FINOS CLA on file

### Documentation

* [ ] Documentation has been added/updated for any new features

### Configuration

* [ ] If configuration schema (`config.schema.json`) was modified:

  * [ ] TypeScript types regenerated (`npm run generate-config-types`)
  * [ ] Schema reference docs regenerated (`npm run gen-schema-doc`)

### Tests

* [x] Unit tests pass (`npm test`)
* [x] Linting and formatting pass (`npm run lint` and `npm run format:check`)
* [x] Type checks pass (`npm run check-types`)
