### PR TITLE
fix: use node instead of npx in CLI tests to prevent flaky failures

### DIFF
--- a/packages/git-proxy-cli/test/testCli.test.ts
+++ b/packages/git-proxy-cli/test/testCli.test.ts
@@ -46,7 +46,7 @@ const TEST_PASSWORD = 'testpassword';
 const TEST_EMAIL = 'jane.doe@email.com';
 const TEST_GIT_ACCOUNT = 'testGitAccount';
 
-const CLI_PATH = 'npx git-proxy-cli';
+const CLI_PATH = 'node packages/git-proxy-cli/dist/index.js';
 
 describe('test git-proxy-cli', function () {
   // *** help ***


### PR DESCRIPTION
## Description

  Replace `npx git-proxy-cli` with `node packages/git-proxy-cli/dist/index.js` in CLI tests to fix intermittent Windows CI failures caused by `npx` subprocess crashes

  ## Related Issue

  Resolves #1549