### PR TITLE
feat: implement disconnect detection, cancel pushes on disconnect

### DIFF
--- a/src/proxy/chain.ts
+++ b/src/proxy/chain.ts
@@ -17,7 +17,7 @@
 import { Request, Response } from 'express';
 
 import { PluginLoader } from '../plugin';
-import { Action, RequestType, PushType } from './actions';
+import { Action, Step, RequestType, PushType } from './actions';
 import * as proc from './processors';
 import { Processor } from './processors/types';
 import { attemptAutoApproval, attemptAutoRejection } from './actions/autoActions';
@@ -57,6 +57,28 @@ const defaultActionChain: Processor['exec'][] = [proc.push.checkRepoInAuthorised
 
 let pluginsInserted = false;
 
+const CLIENT_DISCONNECT_MESSAGE =
+  'Client disconnected while the push was being processed. Push canceled.';
+
+/**
+ * Detect whether the git client that initiated this request has disconnected
+ *
+ * For HTTPS, pack data is fully buffered before the chain runs,
+ * so we check for a destroyed socket (couldn't have been delivered anyway)
+ *
+ * For SSH we flag the ssh2 connection as disconnected by the SSH server
+ * on connection end/close events.
+ * @param {Request} req The request being processed by the chain.
+ * @return {boolean} true when the client is known to be gone.
+ */
+const isClientDisconnected = (req: Request): boolean => {
+  const sshReq = req as Request & { isSSH?: boolean; sshClient?: { disconnected?: boolean } };
+  if (sshReq.isSSH) {
+    return sshReq.sshClient?.disconnected === true;
+  }
+  return req.socket?.destroyed === true;
+};
+
 export const executeChain = async (req: Request, _res: Response): Promise<Action> => {
   let action: Action = {} as Action;
   let checkoutCleanUpRequired = false;
@@ -73,6 +95,18 @@ export const executeChain = async (req: Request, _res: Response): Promise<Action
 
     // 4) Execute each step in the selected chain
     for (const fn of actionFns) {
+      // cancel pushes on disconnect
+      if (action.type === RequestType.PUSH && isClientDisconnected(req)) {
+        console.log(`Client disconnected mid-push, canceling action ${action.id}`);
+        const step = new Step('clientDisconnected');
+        step.log(CLIENT_DISCONNECT_MESSAGE);
+        action.addStep(step);
+        action.canceled = true;
+        action.error = true;
+        action.errorMessage = CLIENT_DISCONNECT_MESSAGE;
+        break;
+      }
+
       action = await fn(req, action);
       if (!action.continue() || action.allowPush) {
         break;

--- a/src/proxy/routes/index.ts
+++ b/src/proxy/routes/index.ts
@@ -86,6 +86,14 @@ const proxyFilter: ProxyOptions['filter'] = async (req, res) => {
       return false;
     }
 
+    // the checks passed, but if the client vanished in the meantime (SIGINT, etc.)
+    // the push must not be forwarded on their behalf
+    if (req.socket?.destroyed) {
+      const message = 'Client disconnected before the push could be forwarded';
+      logAction(req.url, req.headers.host, req.headers['user-agent'], ActionType.ERROR, message);
+      return false;
+    }
+
     logAction(req.url, req.headers.host, req.headers['user-agent'], ActionType.ALLOWED);
 
     // this is the only case where we do not respond directly, instead we return true to proxy the request
@@ -100,6 +108,12 @@ const proxyFilter: ProxyOptions['filter'] = async (req, res) => {
 };
 
 const sendErrorResponse = (req: Request, res: Response, message: string): void => {
+  // nobody is listening on a destroyed socket (e.g. git push killed mid-flight)
+  if (req.socket?.destroyed) {
+    console.log('Client disconnected before the response could be sent, skipping response');
+    return;
+  }
+
   // GET requests to /info/refs (used to check refs for many git operations) must use Git protocol error packet format
   if (req.method === 'GET' && req.url.includes('/info/refs')) {
     res.set('content-type', 'application/x-git-upload-pack-advertisement');

--- a/src/proxy/ssh/server.ts
+++ b/src/proxy/ssh/server.ts
@@ -181,11 +181,13 @@ export class SSHServer {
 
     client.on('end', () => {
       console.log(`[SSH] Client disconnected from ${clientIp}`);
+      clientWithUser.disconnected = true;
       clearTimeout(connectionTimeout);
     });
 
     client.on('close', () => {
       console.log(`[SSH] Client connection closed from ${clientIp}`);
+      clientWithUser.disconnected = true;
       clearTimeout(connectionTimeout);
     });
 
@@ -600,6 +602,10 @@ export class SSHServer {
           `[SSH] Chain execution failed for user ${client.authenticatedUser?.username}:`,
           chainError,
         );
+        if (client.disconnected) {
+          console.log('[SSH] Client already disconnected, skipping error response');
+          return;
+        }
         const errorMessage = chainError instanceof Error ? chainError.message : String(chainError);
         stream.stderr.write(`Access denied: ${errorMessage}\n`);
         stream.exit(1);

--- a/src/proxy/ssh/types.ts
+++ b/src/proxy/ssh/types.ts
@@ -70,4 +70,6 @@ export interface ClientWithUser extends ssh2.Connection, SSH2ConnectionInternals
   agentForwardingEnabled?: boolean;
   agentChannel?: ssh2.Channel;
   agentProxy?: SSHAgentProxy;
+  /** Set when the client connection ends/closes, so in-flight chains can cancel. */
+  disconnected?: boolean;
 }

--- a/test/chain.test.ts
+++ b/test/chain.test.ts
@@ -454,6 +454,90 @@ describe('proxy chain', function () {
     expect(consoleErrorSpy).toHaveBeenCalledWith('Error during auto-rejection: Database error');
   });
 
+  describe('client disconnect detection', () => {
+    const newPushAction = () => {
+      const action = new Action(
+        'disconnect-test',
+        RequestType.PUSH,
+        'POST',
+        Date.now(),
+        'https://github.com/owner/repo.git',
+      );
+      mockPreProcessors.parseAction.mockResolvedValue(action);
+      mockPreProcessors.parsePush.mockResolvedValue(action);
+      return action;
+    };
+
+    it('should cancel the push when the HTTP client has already disconnected', async () => {
+      newPushAction();
+      const req = { socket: { destroyed: true } };
+
+      const result = await chain.executeChain(req);
+
+      expect(result.canceled).toBe(true);
+      expect(result.error).toBe(true);
+      expect(result.errorMessage).toContain('Client disconnected');
+
+      // no checks ran and the push was not queued for approval
+      expect(mockPushProcessors.checkRepoInAuthorisedList).not.toHaveBeenCalled();
+      expect(mockPushProcessors.blockForAuth).not.toHaveBeenCalled();
+
+      // the canceled push is still audited
+      expect(mockPostProcessors.audit).toHaveBeenCalled();
+    });
+
+    it('should cancel the push when the HTTP client disconnects mid-chain', async () => {
+      newPushAction();
+      const req: any = { socket: { destroyed: false } };
+
+      // simulate the client vanishing while a check is running
+      mockPushProcessors.checkUserPushPermission.mockImplementation(async (r: any, action: any) => {
+        r.socket.destroyed = true;
+        return action;
+      });
+
+      const result = await chain.executeChain(req);
+
+      expect(result.canceled).toBe(true);
+      expect(result.error).toBe(true);
+
+      // steps before the disconnect ran, later steps did not
+      expect(mockPushProcessors.checkUserPushPermission).toHaveBeenCalled();
+      expect(mockPushProcessors.pullRemote).not.toHaveBeenCalled();
+      expect(mockPushProcessors.scanDiff).not.toHaveBeenCalled();
+      expect(mockPushProcessors.blockForAuth).not.toHaveBeenCalled();
+      expect(mockPostProcessors.audit).toHaveBeenCalled();
+    });
+
+    it('should cancel the push when the SSH client disconnects mid-chain', async () => {
+      newPushAction();
+      const sshClient = { disconnected: false };
+      const req: any = { isSSH: true, sshClient };
+
+      mockPushProcessors.checkMessages.mockImplementation(async (r: any, action: any) => {
+        sshClient.disconnected = true;
+        return action;
+      });
+
+      const result = await chain.executeChain(req);
+
+      expect(result.canceled).toBe(true);
+      expect(result.error).toBe(true);
+      expect(mockPushProcessors.checkAuthorEmails).not.toHaveBeenCalled();
+      expect(mockPushProcessors.blockForAuth).not.toHaveBeenCalled();
+    });
+
+    it('should not cancel pushes for connected clients', async () => {
+      newPushAction();
+      const req = { socket: { destroyed: false } };
+
+      const result = await chain.executeChain(req);
+
+      expect(result.canceled).toBe(false);
+      expect(mockPushProcessors.blockForAuth).toHaveBeenCalled();
+    });
+  });
+
   it('returns pullActionChain for pull actions', async () => {
     const action = new Action(
       '1',


### PR DESCRIPTION
## Description

Implements disconnect detection which marks pushes as canceled if the connection to the client is lost (such as when sending SIGINT after calling `git push`, or internet disconnection).

Originally developed in Fogwall, and explained [here](https://gist.github.com/coopernetes/d02d48efa759282ff8187da0d5dcae64#what-persistent-possession-enables). This PR demonstrates that implementing persistent clones isn't necessary for detecting client disconnects.

A new step called `clientDisconnected` is added if the connection was lost - so the UI clearly reports the canceled status and reason for canceling:

<img width="802" height="894" alt="image" src="https://github.com/user-attachments/assets/289f3208-f589-47d1-b978-5abf7674c633" />

### Client-side

<img width="518" height="145" alt="image" src="https://github.com/user-attachments/assets/bccf0f3f-e251-4021-a044-5b7e3558ffeb" />

### Server-side

Note that `clearBareClone` runs in the `finally` block (right after `clientDisconnected` "step" is logged.

<img width="685" height="453" alt="image" src="https://github.com/user-attachments/assets/f14fd6d8-62a2-45c9-8ac8-f72da7b1fc50" />

## Related Issue

Resolves #

## Checklist

### General

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have a [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) on file

### Documentation

- [ ] Documentation has been added/updated for any new features

### Tests

- [x] Tests have been added/updated for new functionality
- [x] Unit tests pass (`npm test`)
- [x] Linting and formatting pass (`npm run lint` and `npm run format:check`)
- [x] Type checks pass (`npm run check-types`)
