### PR TITLE
fix(proxy): #1588 accept smart-HTTP paths without .git suffix

### DIFF
--- a/src/proxy/routes/helper.ts
+++ b/src/proxy/routes/helper.ts
@@ -68,6 +68,9 @@ export const processGitUrl = (url: string): GitUrlBreakdown | null => {
  * into the embedded git end point and path for the git operation. */
 const PROXIED_URL_PATH_REGEX = /(.+\.git)(\/.*)?/;
 
+/** Fallback for smart-HTTP paths that omit the .git repo suffix (e.g. GitHub-style URLs). */
+const SMART_HTTP_PATH_REGEX = /^(.+?)(\/(?:info\/refs|git-upload-pack|git-receive-pack)(?:\?.*)?)$/;
+
 /** Type representing a breakdown of paths requested from the proxy server */
 export type UrlPathBreakdown = { repoPath: string; gitPath: string };
 
@@ -81,6 +84,11 @@ export type UrlPathBreakdown = { repoPath: string; gitPath: string };
  * - gitPath: /info/refs?service=git-upload-pack
  *
  * and processing /github.com/finos/git-proxy.git/info/refs?service=git-upload-pack
+ * would produce:
+ * - repoPath: /github.com/finos/git-proxy.git
+ * - gitPath: /info/refs?service=git-upload-pack
+ *
+ * Processing /github.com/finos/git-proxy/info/refs?service=git-upload-pack (no .git suffix)
  * would produce:
  * - repoPath: /github.com/finos/git-proxy.git
  * - gitPath: /info/refs?service=git-upload-pack
@@ -100,10 +108,18 @@ export const processUrlPath = (requestPath: string): UrlPathBreakdown | null => 
       repoPath: components[1],
       gitPath: components[2] ?? '/',
     };
-  } else {
-    console.error(`Failed to parse proxy url path: ${requestPath}`);
-    return null;
   }
+
+  const smartHttp = requestPath.match(SMART_HTTP_PATH_REGEX);
+  if (smartHttp) {
+    return {
+      repoPath: smartHttp[1] + '.git',
+      gitPath: smartHttp[2],
+    };
+  }
+
+  console.error(`Failed to parse proxy url path: ${requestPath}`);
+  return null;
 };
 
 /** Regex used to analyze repo URLs (with protocol and origin) to extract the repository name and

--- a/src/proxy/routes/index.ts
+++ b/src/proxy/routes/index.ts
@@ -281,7 +281,7 @@ const proxyErrorHandler: ProxyOptions['proxyErrorHandler'] = (err, _res, next) =
 
 const isPackPost = (req: Request) =>
   req.method === 'POST' &&
-  /^(?:\/[^/]+)*\/[^/]+\.git\/(?:git-upload-pack|git-receive-pack)$/.test(req.url);
+  /^(?:\/[^/]+)*\/[^/]+(?:\.git)?\/(?:git-upload-pack|git-receive-pack)$/.test(req.url);
 
 const extractRawBody = async (req: Request, res: Response, next: NextFunction) => {
   if (!isPackPost(req)) {

--- a/test/extractRawBody.test.ts
+++ b/test/extractRawBody.test.ts
@@ -91,6 +91,13 @@ describe('isPackPost()', () => {
     expect(isPackPost({ method: 'POST', url: '/a.git/git-upload-pack' } as Request)).toBe(true);
   });
 
+  it('returns true for git-upload-pack POST without a .git repo suffix', () => {
+    expect(isPackPost({ method: 'POST', url: '/a/b/git-upload-pack' } as Request)).toBe(true);
+    expect(
+      isPackPost({ method: 'POST', url: '/github.com/org/repo/git-receive-pack' } as Request),
+    ).toBe(true);
+  });
+
   it('returns false for other URLs', () => {
     expect(isPackPost({ method: 'POST', url: '/info/refs' } as Request)).toBe(false);
   });

--- a/test/testProxyRoute.test.ts
+++ b/test/testProxyRoute.test.ts
@@ -392,6 +392,21 @@ describe('proxyFilter', () => {
       expect(mockReq.body).toEqual(Buffer.from('test data'));
       expect((mockReq as any).bodyRaw).toBeUndefined();
     });
+
+    it('should allow GET info/refs for a .git-less smart-HTTP path without mocking processUrlPath', async () => {
+      mockReq.url = '/github.com/finos/git-proxy/info/refs?service=git-upload-pack';
+      mockReq.method = 'GET';
+
+      vi.spyOn(chain, 'executeChain').mockResolvedValue({
+        error: false,
+        blocked: false,
+      } as Action);
+
+      const result = await proxyFilter?.(mockReq as Request, mockRes as Response);
+
+      expect(result).toBe(true);
+      expect(sendMock).not.toHaveBeenCalled();
+    });
   });
 
   describe('Invalid requests', () => {

--- a/test/testRouteFilter.test.ts
+++ b/test/testRouteFilter.test.ts
@@ -75,6 +75,25 @@ describe('url helpers and filter functions used in the proxy', () => {
     expect(processUrlPath(VERY_LONG_PATH)).toBeNull();
   });
 
+  it('processUrlPath should parse smart-HTTP paths without a .git repo suffix', () => {
+    expect(processUrlPath('/octocat/hello-world/info/refs?service=git-upload-pack')).toEqual({
+      repoPath: '/octocat/hello-world.git',
+      gitPath: '/info/refs?service=git-upload-pack',
+    });
+
+    expect(
+      processUrlPath('/github.com/octocat/hello-world/info/refs?service=git-upload-pack'),
+    ).toEqual({
+      repoPath: '/github.com/octocat/hello-world.git',
+      gitPath: '/info/refs?service=git-upload-pack',
+    });
+
+    expect(processUrlPath('/org/owner/repo/git-upload-pack')).toEqual({
+      repoPath: '/org/owner/repo.git',
+      gitPath: '/git-upload-pack',
+    });
+  });
+
   it('processGitUrl should return breakdown of a git URL separating out the protocol, host and repository path', () => {
     expect(processGitUrl('https://somegithost.com/octocat/hello-world.git')).toEqual({
       protocol: 'https://',


### PR DESCRIPTION
<!--
  Thanks for contributing to GitProxy!
  Please read CONTRIBUTING.md before submitting your PR:
  https://github.com/finos/git-proxy/blob/main/CONTRIBUTING.md
-->

## Description

Git smart-HTTP clients may send repository paths **without a `.git` suffix** (e.g. `GET /owner/repo/info/refs?service=git-upload-pack`). GitHub accepts this form; Git Proxy previously did not.

- `processUrlPath` only matched paths containing `.git` (`(.+\.git)(\/.*)?`). For `.git`-less smart-HTTP URLs it returned `null`, so - `proxyFilter` rejected the request with `Invalid request received` before the plugin chain ran.

This PR fixes that in two places (both are required for a full clone/fetch):

1. `processUrlPath` - after the existing `.git` regex, add a smart-HTTP suffix fallback for paths ending in `/info/refs`, `/git-upload-pack`, or `/git-receive-pack`. Normalise `repoPath` to end with `.git` internally so `parseAction` and `getRepoByUrl` continue to work unchanged.

2. `isPackPost` - make `.git` optional in the POST pack URL regex so `POST /owner/repo/git-upload-pack` is recognised and `extractRawBody` runs. Without this, discovery could succeed but clone/fetch would still fail on the second HTTP request.

**Complementary to, not a substitute for:** v1->v2 DB URL migration (#1535 / #1543), which normalises stored `repos.url`. This PR fixes **inbound wire paths** clients send at runtime.

## Related Issue

Resolves #1588

## Checklist

### General

- [x] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have a [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) on file

### Documentation

- [ ] Documentation has been added/updated for any new features

_N/A — behaviour fix aligned with GitHub/git client conventions; no new user-facing configuration._

### Configuration

- [ ] If configuration schema (`config.schema.json`) was modified:
- [ ] TypeScript types regenerated (`npm run generate-config-types`)
- [ ] Schema reference docs regenerated (`npm run gen-schema-doc`)

_N/A — `config.schema.json` not modified._

### Tests

- [x] Tests have been added/updated for new functionality
- [x] Unit tests pass (`npm test`)
- [x] Linting and formatting pass (`npm run lint` and `npm run format:check`)
- [x] Type checks pass (`npm run check-types`)

**Local verification:** `npm test` (1141 passed), `npm run lint`, Prettier on changed files.

## Test plan

- [x] `processUrlPath('/octocat/hello-world/info/refs?service=git-upload-pack')` → `repoPath: /octocat/hello-world.git`
- [x] `processUrlPath('/github.com/octocat/hello-world/info/refs?service=git-upload-pack')` → proxied host path with `.git` normalised
- [x] `processUrlPath('/org/owner/repo/git-upload-pack')` → pack path parsed
- [x] Regression: paths with `.git` unchanged (`/octocat/hello-world.git/info/refs?...`, `/octocat/hello-world.git`, `/octocat/hello-world.git/`)
- [x] `isPackPost` true for `POST /a/b/git-upload-pack` and `POST /a/b.git/git-upload-pack`
- [x] `proxyFilter` allows `GET /github.com/finos/git-proxy/info/refs?service=git-upload-pack` without mocking `processUrlPath`
- [ ] Manual: `curl -H "User-Agent: git/2.43.0" "http://<proxy>/owner/repo/info/refs?service=git-upload-pack"` against authorised repo (both with and without `.git` in path)