### PR TITLE
fix: bumper workflow lockfile errors on generated PR

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,8 +16,6 @@ permissions:
   contents: write
   pull-requests: write
 
-env:
-  NODE_VERSION: 22
 
 concurrency:
   group: version-bump-${{ github.event.milestone.number || github.run_id }}
@@ -71,18 +69,16 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts --no-audit --no-fund
-
-      - name: Bump root and workspace packages
+      - name: Bump root package
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: |
-          npm version "$VERSION" \
-            --no-git-tag-version \
-            --allow-same-version \
-            --workspaces \
-            --include-workspace-root
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - name: Bump git-proxy-cli package
+        working-directory: packages/git-proxy-cli
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
       - name: Sync git-proxy-cli's pin on the root package
         env:
@@ -117,7 +113,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "$BRANCH"
-          git add package.json package-lock.json packages/*/package.json
+          git add package.json package-lock.json packages/git-proxy-cli/package.json
           git commit -m "chore: bump git-proxy and git-proxy-cli to $VERSION"
           git push -u origin "$BRANCH" --force-with-lease
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -16,7 +16,6 @@ permissions:
   contents: write
   pull-requests: write
 
-
 concurrency:
   group: version-bump-${{ github.event.milestone.number || github.run_id }}
   cancel-in-progress: false

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -14,6 +14,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  NODE_VERSION: 22
+
 concurrency:
   group: version-bump-${{ github.event.milestone.number || github.run_id }}
   cancel-in-progress: false
@@ -35,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '24'
+          node-version: ${{ env.NODE_VERSION }}
 
       - name: Resolve version
         id: version
@@ -77,6 +80,25 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
+      - name: Sync git-proxy-cli's pin on the root package
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          node -e '
+            const fs = require("fs");
+            const p = "packages/git-proxy-cli/package.json";
+            const pkg = JSON.parse(fs.readFileSync(p, "utf8"));
+            if (!pkg.dependencies || !pkg.dependencies["@finos/git-proxy"]) {
+              console.error("::error::Expected @finos/git-proxy in git-proxy-cli dependencies.");
+              process.exit(1);
+            }
+            pkg.dependencies["@finos/git-proxy"] = process.env.VERSION;
+            fs.writeFileSync(p, JSON.stringify(pkg, null, 2) + "\n");
+          '
+
+      - name: Refresh the lockfile
+        run: npm install --package-lock-only --no-audit --no-fund
+
       - name: Open version bump PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +115,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add package.json package-lock.json packages/git-proxy-cli/package.json
           git commit -m "chore: bump git-proxy and git-proxy-cli to $VERSION"
-          git push -u origin "$BRANCH" --force
+          git push -u origin "$BRANCH" --force-with-lease
 
           if [ -n "$MILESTONE_URL" ]; then
             SOURCE_LINE="Triggered by closing milestone **$MILESTONE_TITLE** ($MILESTONE_URL)."
@@ -101,7 +123,7 @@ jobs:
             SOURCE_LINE="Triggered manually for version $VERSION."
           fi
 
-          BODY=$(printf '%s\n\nBumps:\n- `package.json`, `package-lock.json`\n- `packages/git-proxy-cli/package.json`\n\nOnce merged, cut `%s` from `main` per our [release process](https://git-proxy.finos.org/docs/development/releases) in order to generate a GitHub draft release.\n' "$SOURCE_LINE" "$RELEASE_BRANCH")
+          BODY=$(printf '%s\n\nBumps:\n- `package.json`, `package-lock.json`\n- `packages/git-proxy-cli/package.json` (including its pin on `@finos/git-proxy`)\n\nOnce merged, cut `%s` from `main` per our [release process](https://git-proxy.finos.org/docs/development/releases) in order to generate a GitHub draft release.\n' "$SOURCE_LINE" "$RELEASE_BRANCH")
 
           if gh pr view "$BRANCH" >/dev/null 2>&1; then
             echo "PR for $BRANCH already exists. Branch updated, no new PR opened."


### PR DESCRIPTION
## Description

Follow-up for #1669 which wasn't the right fix (the real issue was syncing the git-proxy dependency pinning on the git-proxy-cli package).

## Related Issue

<!-- Link the issue this PR addresses. Use a closing keyword to auto-close it on merge. -->
<!-- Example: Resolves #123 -->

Resolves #

## Checklist

<!-- Check items that apply by replacing [ ] with [x]. -->

### General

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have a [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) on file

### Documentation

<!--
  Documentation lives in two locations:
  - website/docs/ — User-facing docs published to https://git-proxy.finos.org (quickstart, configuration, deployment)
  - docs/ — Technical docs such as architecture, processors, and upgrade guides
-->

- [ ] Documentation has been added/updated for any new features

### Configuration

<!--
  If you modified config.schema.json, you must regenerate types and docs:
  - npm run generate-config-types (regenerates src/config/generated-config-types.ts)
  - npm run gen-schema-doc (regenerates website/docs/configuration/reference.md)
-->

- [ ] If configuration schema (`config.schema.json`) was modified:
  - [ ] TypeScript types regenerated (`npm run generate-config-types`)
  - [ ] Schema reference docs regenerated (`npm run gen-schema-doc`)

### Tests

<!--
  Tests are required for new functionality (80%+ patch coverage enforced by CodeCov).
  Add tests in the appropriate location:
  - test/          — Unit and integration tests (Vitest). Organised by module (processors/, db/, services/, plugin/, etc.)
  - tests/e2e/     — End-to-end tests (Vitest + Docker). Real git operations against a containerised environment.
  - cypress/e2e/   — UI tests (Cypress). Dashboard UI end-to-end tests.
-->

- [ ] Tests have been added/updated for new functionality
- [ ] Unit tests pass (`npm test`)
- [ ] Linting and formatting pass (`npm run lint` and `npm run format:check`)
- [ ] Type checks pass (`npm run check-types`)
