### PR TITLE
fix: broken UI build path (release/2.0 branch)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
           npm run test-coverage-ci
           npm run test-coverage-ci --workspaces --if-present
 
+      # Smoke test deliberately removed due to long running times
       - name: Build frontend
         run: npm run build-ui
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,6 +2,16 @@ name: Publish to NPM
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        required: false
+        default: 'true'
+        type: choice
+        options:
+          - 'true'
+          - 'false'
+
 permissions:
   contents: read
   id-token: write
@@ -11,26 +21,61 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
         with:
           egress-policy: audit
 
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       # Setup .npmrc file to publish to npm
-      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
 
-      - name: Check if pre-release and publish to NPM
+      - name: Smoke test package before publishing
+        run: ./scripts/package-smoke-test.sh --no-clean-build
+
+      - name: Determine dist-tag and publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
         run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
+          PKG_NAME=$(node -p "require('./package.json').name")
+          echo "Publishing $PKG_NAME@$VERSION"
+
+          # Build the publish command flags.
+          PUBLISH_FLAGS=(--access=public)
+          if [[ "$DRY_RUN" == "true" ]]; then
+            PUBLISH_FLAGS+=(--dry-run)
+            echo "DRY RUN — nothing will actually be published."
+          fi
+
+          # Pre-releases (ex: 2.1.0-rc.1) get tagged as 'rc'
           if [[ "$VERSION" == *"-"* ]]; then
-            echo "Publishing pre-release: $VERSION"
-            npm publish --access=public --tag rc
+            echo "Pre-release detected, publishing under 'rc' tag"
+            npm publish "${PUBLISH_FLAGS[@]}" --tag rc
+            exit 0
+          fi
+
+          # Look up current 'latest' on NPM. If never published before,
+          # defaults to 0.0.0 so any release (0.1.0, 1.0.0, etc.) becomes latest
+          CURRENT_LATEST=$(npm view "$PKG_NAME" version 2>/dev/null || echo "0.0.0")
+          echo "Current 'latest' on npm: $CURRENT_LATEST"
+
+          # If this version is strictly greater than the current 'latest',
+          # it becomes latest
+          if npx --yes semver "$VERSION" -r ">$CURRENT_LATEST" >/dev/null 2>&1; then
+            echo "Publishing as 'latest'"
+            npm publish "${PUBLISH_FLAGS[@]}"
           else
-            echo "Publishing stable release: $VERSION"
-            npm publish --access=public
+            # Otherwise, this is a maintenance release on an older line
+            # Tag as v<major>.<minor> so users can pin to it
+            MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+            DIST_TAG="release-${MAJOR_MINOR}"
+            echo "Maintenance release detected, publishing under '$DIST_TAG' tag"
+            npm publish "${PUBLISH_FLAGS[@]}" --tag "$DIST_TAG"
           fi

--- a/.github/workflows/package-smoke-test.yml
+++ b/.github/workflows/package-smoke-test.yml
@@ -1,0 +1,39 @@
+# This workflow builds the package and checks that the build is correct
+# (includes the UI files)
+
+name: Package Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  smoke-test-package:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.x
+
+      - name: Install dependencies
+        run: npm ci --no-fund
+
+      - name: Build
+        run: npm run build
+
+      - name: Smoke test build
+        run: bash ./scripts/package-smoke-test.sh --no-clean-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,9 +121,10 @@ git-proxy/
 ### Building
 
 ```bash
-npm run build          # Full build: generate config types, build UI, compile TypeScript
-npm run build-ts       # Compile TypeScript server code to dist/
-npm run build-ui       # Build React frontend with Vite to build/
+npm run build            # Full build: generate config types, build UI, compile TypeScript
+npm run build-ts         # Compile TypeScript server code to dist/
+npm run build-ui         # Build React frontend with Vite to build/
+npm run build-validate   # Check that UI files are correctly included in build
 ```
 
 ### Type checking

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,27 +19,24 @@ RUN npm run build-ui \
 
 FROM node:24@sha256:5a593d74b632d1c6f816457477b6819760e13624455d587eef0fa418c8d0777b AS production
 
-COPY --from=builder /out/package*.json ./
-COPY --from=builder /out/node_modules/ /app/node_modules/
-COPY --from=builder /out/dist/ /app/dist/
-COPY --from=builder /out/build /app/dist/build/
-COPY proxy.config.json config.schema.json ./
+WORKDIR /app
+
+# Install deps and create data dirs once
+RUN apt-get update && apt-get install -y --no-install-recommends git tini \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /app/.data /app/.tmp /app/.remote \
+    && chown 1000:1000 /app /app/.data /app/.tmp /app/.remote
+
+COPY --chown=1000:1000 --from=builder /out/package*.json ./
+COPY --chown=1000:1000 --from=builder /out/node_modules/ ./node_modules/
+COPY --chown=1000:1000 --from=builder /out/dist/ ./dist/
+COPY --chown=1000:1000 proxy.config.json config.schema.json ./
 COPY docker-entrypoint.sh /docker-entrypoint.sh
 
-USER root
-
-RUN apt-get update && apt-get install -y \
-    git tini \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /app/.data /app/.tmp /app/.remote \
-    && chown -R 1000:1000 /app
 
 USER 1000
 
-WORKDIR /app
-
-EXPOSE 8080 8000
+EXPOSE 8080 8000 8444
 
 ENTRYPOINT ["tini", "--", "/docker-entrypoint.sh"]
 CMD ["node", "--enable-source-maps", "dist/index.js"]

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "build": "npm run generate-config-types && npm run build-ui && npm run build-ts",
     "build-ts": "tsc --project tsconfig.publish.json && node scripts/fix-shebang.js",
     "build-ui": "vite build",
+    "build-validate": "./scripts/package-smoke-test.sh",
     "check-types": "tsc",
     "check-types:server": "tsc --project tsconfig.publish.json --noEmit",
     "test-shuffle": "NODE_ENV=test vitest --run --dir ./test --sequence.shuffle",

--- a/scripts/package-smoke-test.sh
+++ b/scripts/package-smoke-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CLEAN_BUILD=true
+if [[ "${1:-}" == "--no-clean-build" ]]; then
+  CLEAN_BUILD=false
+fi
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WORK="$(mktemp -d)"
+SERVER_PID=""
+cleanup() {
+  [[ -n "$SERVER_PID" ]] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+cd "$ROOT"
+
+if [[ "$CLEAN_BUILD" == true ]]; then
+  echo "Building from a clean slate..."
+  rm -rf dist build
+  npm run build
+fi
+
+TARBALL="$WORK/$(npm pack --silent --pack-destination "$WORK")"
+echo "Packed: $TARBALL"
+FILES="$(tar tzf "$TARBALL")"
+
+# UI must be inside the tarball
+if ! grep -qx 'package/dist/build/index.html' <<<"$FILES"; then
+  echo "FAIL: dist/build/index.html is missing from the tarball."
+  echo "--- everything under dist/build ---"
+  grep '^package/dist/build' <<<"$FILES" || echo "(dist/build is entirely absent)"
+  echo "--- top level ---"
+  sed 's|^package/||' <<<"$FILES" | cut -d/ -f1 | sort -u
+  exit 1
+fi
+
+grep -qE '^package/dist/build/assets/.+\.js$' <<<"$FILES" \
+  || { echo "FAIL: no JS bundle under dist/build/assets."; exit 1; }
+
+# Install like a normal user
+cd "$WORK"
+npm init -y >/dev/null
+npm install --no-audit --no-fund --loglevel=error "$TARBALL"
+
+if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+  echo "FAIL: port 8080 is already in use, refusing to test against a foreign server."
+  exit 1
+fi
+
+# Boot from a scratch cwd so it writes its .data/.tmp
+mkdir -p "$WORK/run" && cd "$WORK/run"
+"$WORK/node_modules/.bin/git-proxy" > "$WORK/server.log" 2>&1 &
+SERVER_PID=$!
+
+for i in $(seq 1 60); do
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo "FAIL: server exited before answering (see log below)"
+    cat "$WORK/server.log"
+    exit 1
+  fi
+  curl -fsS http://localhost:8080/api/v1/healthcheck >/dev/null 2>&1 && break
+  if [[ $i -eq 60 ]]; then
+    echo "FAIL: server did not come up within 60s"
+    cat "$WORK/server.log"
+    exit 1
+  fi
+  sleep 1
+done
+
+# Check UI wrapper is served 
+HTML="$(curl -fsS http://localhost:8080/)"
+if ! grep -q '<div id="root">' <<<"$HTML"; then
+  echo "FAIL: / did not return the GitProxy UI wrapper."
+  head -30 <<<"$HTML"
+  exit 1
+fi
+
+# The bundled reference must resolve, not just exist as a string
+ASSET="$(grep -oE '/assets/[A-Za-z0-9._-]+\.js' <<<"$HTML" | head -1)"
+[[ -n "$ASSET" ]] || { echo "FAIL: index.html references no JS bundle."; exit 1; }
+curl -fsS -o /dev/null "http://localhost:8080$ASSET" \
+  || { echo "FAIL: $ASSET 404s."; exit 1; }
+
+echo "PASS: packaged UI installs and serves correctly ($ASSET)"

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -28,6 +28,7 @@ import { serverConfig } from '../config/env';
 import { Proxy } from '../proxy';
 import routes from './routes';
 import { configure } from './passport';
+import { UI_BUILD_PATH } from './urls';
 
 const limiter = rateLimit(config.getRateLimit());
 
@@ -129,7 +130,7 @@ async function createApp(proxy: Proxy): Promise<Express> {
   // configuration of passport is async
   // Before we can bind the routes - we need the passport strategy
   const passport = await configure();
-  const absBuildPath = path.join(__dirname, '../../build');
+  const absBuildPath = UI_BUILD_PATH;
   app.use(cors(corsOptions));
   app.set('trust proxy', 1);
   app.use(limiter);
@@ -168,9 +169,14 @@ async function createApp(proxy: Proxy): Promise<Express> {
   app.use('/', routes(proxy));
   app.use('/', express.static(absBuildPath));
   app.get('/*path', (_req, res) => {
-    res.sendFile(path.join(`${absBuildPath}/index.html`));
+    res.sendFile(path.join(absBuildPath, 'index.html'));
   });
 
+  if (!fs.existsSync(path.join(absBuildPath, 'index.html'))) {
+    console.error(
+      `UI build not found at ${absBuildPath}. The package may have been built or published incorrectly`,
+    );
+  }
   return app;
 }
 

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -21,6 +21,7 @@ import cors from 'cors';
 import path from 'path';
 import rateLimit from 'express-rate-limit';
 import lusca from 'lusca';
+import fs from 'fs';
 
 import * as config from '../config';
 import * as db from '../db';

--- a/src/service/urls.ts
+++ b/src/service/urls.ts
@@ -15,6 +15,8 @@
  */
 
 import { Request } from 'express';
+import path from 'path';
+import fs from 'fs';
 
 import { serverConfig } from '../config/env';
 import * as config from '../config';
@@ -34,3 +36,15 @@ export const getServiceUIURL = (req: Request): string => {
     `${req.protocol}://${req.headers.host}`.replace(`:${PROXY_HTTP_PORT}`, `:${UI_PORT}`)
   );
 };
+
+function findPackageRoot(from: string = __dirname): string {
+  let dir = from;
+  for (;;) {
+    if (fs.existsSync(path.join(dir, 'package.json'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) throw new Error('Could not locate GitProxy package root');
+    dir = parent;
+  }
+}
+
+export const UI_BUILD_PATH = path.join(findPackageRoot(), 'dist', 'build');

--- a/tsconfig.publish.json
+++ b/tsconfig.publish.json
@@ -10,7 +10,6 @@
     "experimental/**",
     "plugins/**",
     "./dist/**",
-    "src/ui/**",
     "**/*.tsx",
     "**/*.jsx",
     "./src/context.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default ({ mode }: { mode: string }) => {
   const env = loadEnv(mode, process.cwd(), '');
   return defineConfig({
     build: {
-      outDir: 'build',
+      outDir: 'dist/build',
     },
     server: {
       port: 3000,


### PR DESCRIPTION
Fixes the broken UI build issue on 2.0 specifically

## Description

## Related Issue
#1703 

## Checklist

<!-- Check items that apply by replacing [ ] with [x]. -->

### General

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have a [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) on file

### Documentation

<!--
  Documentation lives in two locations:
  - website/docs/ — User-facing docs published to https://git-proxy.finos.org (quickstart, configuration, deployment)
  - docs/ — Technical docs such as architecture, processors, and upgrade guides
-->

- [ ] Documentation has been added/updated for any new features

### Configuration

<!--
  If you modified config.schema.json, you must regenerate types and docs:
  - npm run generate-config-types (regenerates src/config/generated-config-types.ts)
  - npm run gen-schema-doc (regenerates website/docs/configuration/reference.md)
-->

- [ ] If configuration schema (`config.schema.json`) was modified:
  - [ ] TypeScript types regenerated (`npm run generate-config-types`)
  - [ ] Schema reference docs regenerated (`npm run gen-schema-doc`)

### Tests

<!--
  Tests are required for new functionality (80%+ patch coverage enforced by CodeCov).
  Add tests in the appropriate location:
  - test/          — Unit and integration tests (Vitest). Organised by module (processors/, db/, services/, plugin/, etc.)
  - tests/e2e/     — End-to-end tests (Vitest + Docker). Real git operations against a containerised environment.
  - cypress/e2e/   — UI tests (Cypress). Dashboard UI end-to-end tests.
-->

- [ ] Tests have been added/updated for new functionality
- [ ] Unit tests pass (`npm test`)
- [ ] Linting and formatting pass (`npm run lint` and `npm run format:check`)
- [ ] Type checks pass (`npm run check-types`)
