### PR TITLE
ci: fix missing release drafter config in 2.0 line

### DIFF
--- a/.github/release-drafter-config.yml
+++ b/.github/release-drafter-config.yml
@@ -1,5 +1,5 @@
 ---
-name-template: 'Version $RESOLVED_VERSION'
+name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
@@ -9,7 +9,7 @@ template: |
 
   ---
 
-  *Full Changelog**: https://github.com/finos/git-proxy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+  **Full Changelog**: https://github.com/finos/git-proxy/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
 
 categories:
   - title: '🚀 Features'
@@ -44,10 +44,7 @@ version-resolver:
 autolabeler:
   - label: 'automation'
     title:
-      - '/^(ci|perf|refactor|test).*/i'
-  - label: 'enhancement'
-    title:
-      - '/^(style).*/i'
+      - '/^(ci|perf|refactor|test|style).*/i'
   - label: 'documentation'
     title:
       - '/^(docs).*/i'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,34 @@
+name: Release Drafter
+
+on:
+  push:
+    branches:
+      - 'release/**'
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # Required to create/update the draft release
+      # Autolabeling runs in a separate workflow so this job only
+      # needs to read merged PRs
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0
+        with:
+          egress-policy: audit
+
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9
+        with:
+          # Target the branch that triggered this run
+          # Ex: "release/2.1" becomes the commitish for the draft
+          commitish: ${{ github.ref_name }}
+          repository: ${{ github.repository }}
+          config-name: release-drafter-config.yml
+          filter-by-commitish: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Only missing in 2.0

<!--
  Thanks for contributing to GitProxy!
  Please read CONTRIBUTING.md before submitting your PR:
  https://github.com/finos/git-proxy/blob/main/CONTRIBUTING.md
-->

## Description

<!-- Provide a clear and concise description of the changes in this PR. -->

## Related Issue

<!-- Link the issue this PR addresses. Use a closing keyword to auto-close it on merge. -->
<!-- Example: Resolves #123 -->

Resolves #

## Checklist

<!-- Check items that apply by replacing [ ] with [x]. -->

### General

- [ ] I have read the [CONTRIBUTING.md](../CONTRIBUTING.md) guidelines
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [ ] I have a [FINOS CLA](https://finosfoundation.atlassian.net/wiki/spaces/FINOS/pages/75530375/Contribution+Compliance+Requirements) on file

### Documentation

<!--
  Documentation lives in two locations:
  - website/docs/ — User-facing docs published to https://git-proxy.finos.org (quickstart, configuration, deployment)
  - docs/ — Technical docs such as architecture, processors, and upgrade guides
-->

- [ ] Documentation has been added/updated for any new features

### Configuration

<!--
  If you modified config.schema.json, you must regenerate types and docs:
  - npm run generate-config-types (regenerates src/config/generated-config-types.ts)
  - npm run gen-schema-doc (regenerates website/docs/configuration/reference.md)
-->

- [ ] If configuration schema (`config.schema.json`) was modified:
  - [ ] TypeScript types regenerated (`npm run generate-config-types`)
  - [ ] Schema reference docs regenerated (`npm run gen-schema-doc`)

### Tests

<!--
  Tests are required for new functionality (80%+ patch coverage enforced by CodeCov).
  Add tests in the appropriate location:
  - test/          — Unit and integration tests (Vitest). Organised by module (processors/, db/, services/, plugin/, etc.)
  - test/e2e/     — End-to-end tests (Vitest + Docker). Real git operations against a containerised environment.
  - cypress/e2e/   — UI tests (Cypress). Dashboard UI end-to-end tests.
-->

- [ ] Tests have been added/updated for new functionality
- [ ] Unit tests pass (`npm test`)
- [ ] Linting and formatting pass (`npm run lint` and `npm run format:check`)
- [ ] Type checks pass (`npm run check-types`)
